### PR TITLE
Update layout direction based on selected culture (language)

### DIFF
--- a/src/Blazor.Server.UI/Components/Localization/LanguageSelector.razor
+++ b/src/Blazor.Server.UI/Components/Localization/LanguageSelector.razor
@@ -2,6 +2,7 @@
 @using Microsoft.Extensions.Options
 @using Blazor.Server.UI.Models.Localization
 @using System.Globalization
+@using Blazor.Server.UI.Services
 
 <MudTooltip Text="@CurrentLanguage">
     <MudMenu Class="mx-1" Icon="@Icons.Material.Outlined.Translate" Color="Color.Default" Direction="Direction.Bottom" OffsetY="true"
@@ -28,6 +29,7 @@
     public List<CultureInfo>? SupportedLanguages { get; set; } = new();
     [Inject] private NavigationManager _navigation { get; set; } = default!;
     [Inject] private IOptions<RequestLocalizationOptions> localizationOptions { get; set; } = default!;
+    [Inject] private LayoutService LayoutService { get; set; }
 
 
     protected override Task OnInitializedAsync()
@@ -38,11 +40,16 @@
     }
 
 
-    private Task ChangeLanguageAsync(string languageCode)
+    private async Task ChangeLanguageAsync(string languageCode)
     {
         CurrentLanguage = languageCode;
         _navigation.NavigateTo(_navigation.BaseUri + "?culture=" + languageCode, forceLoad: true);
-        return Task.CompletedTask;
 
+        if (new CultureInfo(languageCode).TextInfo.IsRightToLeft)
+            await LayoutService.SetRightToLeft();
+        else
+            await LayoutService.SetLeftToRight();
+        
+        await Task.CompletedTask;
     }
 }

--- a/src/Blazor.Server.UI/Components/Shared/UserMenu.razor
+++ b/src/Blazor.Server.UI/Components/Shared/UserMenu.razor
@@ -7,7 +7,7 @@
     <ChildContent>
         <div class="pb-4"
              style="min-width: 260px;margin-bottom:0px!important">
-            <MudCard Elevation="0" Square="true" Style="ma-0">
+            <MudCard Elevation="0" Square="true" Class="ma-0">
                 <MudCardHeader>
                     <CardHeaderAvatar>
                         @if (string.IsNullOrEmpty(UserProfile.Avatar))

--- a/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
@@ -61,10 +61,12 @@
                     <MudText Typo="Typo.body2">@L["The recommended size for uploading images is 640X320"]</MudText>
                     <div class="d-fex">
                         @if (model.Pictures is not null)
+                        {
                             foreach (var img in model.Pictures)
                             {
                                 <MudImage ObjectFit="ObjectFit.Cover"   Height="80" Width="160" Src="@img" Alt="@img" Elevation="25" Class="mr-2 rounded-lg" />
                             }
+                        }
                     </div>
                 </MudItem>
             </MudGrid>

--- a/src/Blazor.Server.UI/Services/Layout/LayoutService.cs
+++ b/src/Blazor.Server.UI/Services/Layout/LayoutService.cs
@@ -69,7 +69,18 @@ public class LayoutService
         _userPreferences.RightToLeft = IsRTL;
         await _userPreferencesService.SaveUserPreferences(_userPreferences);
         OnMajorUpdateOccured();
-
+    }
+    
+    public async Task SetRightToLeft()
+    {
+        if (!IsRTL)
+            await ToggleRightToLeft();
+    }
+    
+    public async Task SetLeftToRight()
+    {
+        if (IsRTL)
+            await ToggleRightToLeft();
     }
 
     public void SetBaseTheme(MudTheme theme)

--- a/src/Infrastructure/Constants/Localization/LocalizationConstants.cs
+++ b/src/Infrastructure/Constants/Localization/LocalizationConstants.cs
@@ -46,6 +46,11 @@ public static class LocalizationConstants
             {
                 Code = "zh-CN",
                 DisplayName = "中文"
+            },
+            new LanguageCode
+            {
+                Code = "ar-iq",
+                DisplayName = "Arabic Iraq"
             }
         };
 }


### PR DESCRIPTION
Set the layout direct to RTL when user select a culture which by default it is RTL (like Arabic),

I added two methods to set the direct from RightToLeft or LeftToRight which it called from LanguageSelector when the user change the language so the CultureInfo of selected language Code detect IsRTL the call the newly created Methods to update the direction.