### PR TITLE
On button "UPLOAD PICTURE" add images to existing list instead of rep…

### DIFF
--- a/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
@@ -77,7 +77,7 @@
                                 <div style="float:left; position: relative; width: 160px; height: 80px; margin: 10px;">
                                     <MudImage ObjectFit="ObjectFit.Cover" Height="80" Width="160" Src="@img" Alt="@img" Elevation="25" Class="mr-2 rounded-lg" />
                                     <div style="position: absolute;top: 0px;right: 0px; z-index: 9999;">
-                                        <MudButton OnClick="@(()=>DeleteImage(@img))" StartIcon="@Icons.Material.Filled.Delete" Variant="Variant.Text" Color="MudBlazor.Color.Error" Size="MudBlazor.Size.Small"></MudButton>
+                                        <MudIconButton OnClick="@(()=>DeleteImage(@img))"   Icon="@Icons.Material.Filled.Delete" aria-label="delete" Color="MudBlazor.Color.Error" Size="MudBlazor.Size.Small"></MudIconButton>
                                     </div>
                                 </div>
                             }

--- a/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
@@ -74,7 +74,12 @@
                         {
                             foreach (var img in model.Pictures)
                             {
-                                <MudImage ObjectFit="ObjectFit.Cover" Height="80" Width="160" Src="@img" Alt="@img" Elevation="25" Class="mr-2 rounded-lg" />
+                                <div style="float:left; position: relative; width: 160px; height: 80px; margin: 10px;">
+                                    <MudImage ObjectFit="ObjectFit.Cover" Height="80" Width="160" Src="@img" Alt="@img" Elevation="25" Class="mr-2 rounded-lg" />
+                                    <div style="position: absolute;top: 0px;right: 0px; z-index: 9999;">
+                                        <MudButton OnClick="@(()=>DeleteImage(@img))" StartIcon="@Icons.Material.Filled.Delete" Variant="Variant.Text" Color="MudBlazor.Color.Error" Size="MudBlazor.Size.Small"></MudButton>
+                                    </div>
+                                </div>
                             }
                         }
                     </div>
@@ -97,13 +102,33 @@
     [EditorRequired][Parameter] public AddEditProductCommand model { get; set; } = default!;
     const long MAXALLOWEDSIZE = 3145728;
     bool _uploading;
+
+    private async Task DeleteImage(string picture)
+    {
+        if (model.Pictures != null)
+        {
+            var parameters = new DialogParameters
+                        {
+                    { nameof(ConfirmationDialog.ContentText), $"{L["Are you sure you want to erase this image?"]}" }
+                        };
+            var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall, FullWidth = true, DisableBackdropClick = true };
+            var dialog = DialogService.Show<ConfirmationDialog>($"{L["Erase imatge"]}", parameters, options);
+            var state = await dialog.Result;
+
+            if (!state.Canceled)
+            {
+                model.Pictures.Remove(picture);
+            }
+        }
+    }
+
     private async Task UploadFiles(InputFileChangeEventArgs e)
     {
         try
         {
             _uploading = true;
             var list = new List<string>();
-            
+
             foreach (var file in e.GetMultipleFiles())
             {
                 try
@@ -133,8 +158,12 @@
                 }
             }
             Snackbar.Add(L["Upload pictures successfully"], MudBlazor.Severity.Info);
-            model.Pictures = list;
-     
+
+            if (model.Pictures is null)
+                model.Pictures = list;
+            else
+                ((List<String>)model.Pictures).AddRange(list);
+
         }
         finally
         {

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.ca-ES.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.ca-ES.resx
@@ -159,4 +159,10 @@
   <data name="The recommended size for uploading images is 640X320" xml:space="preserve">
     <value>El tamany recomenat par a pujar imàtges és 640X320</value>
   </data>
+  <data name="Are you sure you want to erase this image?" xml:space="preserve">
+    <value>Esteu segur que voleu esborrar aquesta imatge?</value>
+  </data>
+  <data name="Erase imatge" xml:space="preserve">
+    <value>Borrar imatge</value>
+  </data>
 </root>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.ca-ES.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.ca-ES.resx
@@ -162,7 +162,7 @@
   <data name="Are you sure you want to erase this image?" xml:space="preserve">
     <value>Esteu segur que voleu esborrar aquesta imatge?</value>
   </data>
-  <data name="Erase imatge" xml:space="preserve">
+  <data name="Erase image" xml:space="preserve">
     <value>Borrar imatge</value>
   </data>
 </root>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.en.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.en.resx
@@ -159,4 +159,13 @@
   <data name="The recommended size for uploading images is 640X320" xml:space="preserve">
     <value>The recommended size for uploading images is 640X320</value>
   </data>
+  <data name="Are you sure you want to erase this image?" xml:space="preserve">
+    <value>Are you sure you want to erase this image?</value>
+  </data>
+  <data name="Upload picture" xml:space="preserve">
+    <value>Upload picture</value>
+  </data>
+  <data name="Erase image" xml:space="preserve">
+    <value>Erase image</value>
+  </data>
 </root>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.es-ES.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.es-ES.resx
@@ -162,7 +162,7 @@
   <data name="Are you sure you want to erase this image?" xml:space="preserve">
     <value>¿Estás seguro de que quieres borrar esta imagen?</value>
   </data>
-  <data name="Erase imatge" xml:space="preserve">
+  <data name="Erase image" xml:space="preserve">
     <value>Borrar imagen</value>
   </data>
 </root>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.es-ES.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.es-ES.resx
@@ -159,4 +159,10 @@
   <data name="The recommended size for uploading images is 640X320" xml:space="preserve">
     <value>El tamaño recomendado para subir imágenes es 640X320</value>
   </data>
+  <data name="Are you sure you want to erase this image?" xml:space="preserve">
+    <value>¿Estás seguro de que quieres borrar esta imagen?</value>
+  </data>
+  <data name="Erase imatge" xml:space="preserve">
+    <value>Borrar imagen</value>
+  </data>
 </root>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.resx
@@ -126,8 +126,8 @@
   <data name="Description" xml:space="preserve">
     <value>Description</value>
   </data>
-  <data name="Erase imatge" xml:space="preserve">
-    <value>Erase imatge</value>
+  <data name="Erase image" xml:space="preserve">
+    <value>Erase image</value>
   </data>
   <data name="Price" xml:space="preserve">
     <value>Price</value>
@@ -164,5 +164,8 @@
   </data>
   <data name="Unit" xml:space="preserve">
     <value>Unit</value>
+  </data>
+  <data name="Upload picture" xml:space="preserve">
+    <value>Upload picture</value>
   </data>
 </root>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.resx
@@ -117,11 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Are you sure you want to erase this image?" xml:space="preserve">
+    <value>Are you sure you want to erase this image?</value>
+  </data>
   <data name="Brand Name" xml:space="preserve">
     <value>Brand Name</value>
   </data>
   <data name="Description" xml:space="preserve">
     <value>Description</value>
+  </data>
+  <data name="Erase imatge" xml:space="preserve">
+    <value>Erase imatge</value>
   </data>
   <data name="Price" xml:space="preserve">
     <value>Price</value>

--- a/src/Blazor.Server.UI/Resources/Pages/Products/Products.zh-CN.resx
+++ b/src/Blazor.Server.UI/Resources/Pages/Products/Products.zh-CN.resx
@@ -159,4 +159,13 @@
   <data name="The recommended size for uploading images is 640X320" xml:space="preserve">
     <value>建议上传的图片尺寸:640x320</value>
   </data>
+  <data name="Upload picture" xml:space="preserve">
+    <value>上传图片</value>
+  </data>
+  <data name="Are you sure you want to erase this image?" xml:space="preserve">
+    <value>你确定要删除图片吗?</value>
+  </data>
+  <data name="Erase image" xml:space="preserve">
+    <value>删除图片</value>
+  </data>
 </root>


### PR DESCRIPTION
On button "UPLOAD PICTURE" add images to existing list instead of replace all the list.
Add "Erase button" to each picture. It shows a confirmation dialog before erase image.
"Erase imatge" and "Are you sure you want to erase this image?" added to Products.resx, es-ES and ca-ES.
Sample video:

![PicturesEdit](https://user-images.githubusercontent.com/30647662/217497966-e0ec49be-1dd2-40d7-8a74-38d9f51042de.gif)
