### PR TITLE
refacing signalR

### DIFF
--- a/src/Infrastructure/Extensions/SignalRServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/SignalRServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ public static class SignalRServiceCollectionExtensions
     {
         services.AddSingleton<IUsersStateContainer, UsersStateContainer>()
             .AddScoped<CircuitHandler, CircuitHandlerService>()
-            .AddTransient<HubClient>()
+            .AddScoped<HubClient>()
             .AddSignalR();
     }
 }

--- a/src/Infrastructure/Hubs/HubClient.cs
+++ b/src/Infrastructure/Hubs/HubClient.cs
@@ -49,8 +49,6 @@ public class HubClient : IAsyncDisposable
     }
     public async Task StartAsync(CancellationToken cancellation = default)
     {
-        //if (_hubConnection.State != HubConnectionState.Disconnected)
-        //    throw new ApplicationException("Connection is in progress or has already been established");
         if (_started) return;
         _started = true;
         await _hubConnection.StartAsync(cancellation);

--- a/src/Infrastructure/Hubs/HubClient.cs
+++ b/src/Infrastructure/Hubs/HubClient.cs
@@ -4,52 +4,68 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace CleanArchitecture.Blazor.Infrastructure.Hubs;
+
 public class HubClient : IAsyncDisposable
 {
+    public delegate Task MessageReceivedEventHandler(object sender, MessageReceivedEventArgs e);
+
     private readonly HubConnection _hubConnection;
-    private bool _started = false;
+    private bool _started;
+
     public HubClient(NavigationManager navigationManager,
-        AccessTokenProvider  authProvider
-)
+        AccessTokenProvider authProvider
+    )
     {
-        var token = authProvider.AccessToken;
+        string? token = authProvider.AccessToken;
         string hubUrl = navigationManager.BaseUri.TrimEnd('/') + SignalR.HubUrl;
         _hubConnection = new HubConnectionBuilder()
-              .WithUrl(hubUrl, options => {
-                  options.AccessTokenProvider =()=> Task.FromResult(token);
-                  options.Transports = HttpTransportType.WebSockets;
-                  })
-              .Build();
+            .WithUrl(hubUrl, options =>
+            {
+                options.AccessTokenProvider = () => Task.FromResult(token);
+                options.Transports = HttpTransportType.WebSockets;
+            })
+            .Build();
         _hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
-        _hubConnection.On<string>(SignalR.OnConnect, (userId) =>
+        _hubConnection.On<string>(SignalR.OnConnect, userId =>
         {
             Login?.Invoke(this, userId);
         });
 
-        _hubConnection.On<string>(SignalR.OnDisconnect, (userId) =>
+        _hubConnection.On<string>(SignalR.OnDisconnect, userId =>
         {
             Logout?.Invoke(this, userId);
         });
-        _hubConnection.On<string>(SignalR.SendNotification, (message) =>
+        _hubConnection.On<string>(SignalR.SendNotification, message =>
         {
             NotificationReceived?.Invoke(this, message);
         });
-        _hubConnection.On<string, string>(SignalR.SendMessage, (from,message) =>
-        {
-            HandleReceiveMessage(from,message);
-        });
-        _hubConnection.On<string>(SignalR.JobCompleted, (message) =>
+        _hubConnection.On<string, string>(SignalR.SendMessage, HandleReceiveMessage);
+        _hubConnection.On<string>(SignalR.JobCompleted, message =>
         {
             JobCompleted?.Invoke(this, message);
         });
-        _hubConnection.On<string>(SignalR.JobStart, (message) =>
+        _hubConnection.On<string>(SignalR.JobStart, message =>
         {
             JobStarted?.Invoke(this, message);
         });
     }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { await _hubConnection.StopAsync(); }
+        finally
+        {
+            await _hubConnection.DisposeAsync();
+        }
+    }
+
     public async Task StartAsync(CancellationToken cancellation = default)
     {
-        if (_started) return;
+        if (_started)
+        {
+            return;
+        }
+
         _started = true;
         await _hubConnection.StartAsync(cancellation);
     }
@@ -60,30 +76,23 @@ public class HubClient : IAsyncDisposable
         // raise an event to subscribers
         MessageReceived?.Invoke(this, new MessageReceivedEventArgs(from, message));
     }
-    
+
     public async Task SendAsync(string message)
     {
         await _hubConnection.SendAsync(SignalR.SendMessage, message);
     }
+
     public async Task NotifyAsync(string message)
     {
         await _hubConnection.SendAsync(SignalR.SendNotification, message);
     }
-    public async ValueTask DisposeAsync()
-    {
-        try { await _hubConnection.StopAsync(); }
-        finally
-        {
-            await _hubConnection.DisposeAsync();
-        }
-    }
+
     public event EventHandler<string>? Login;
     public event EventHandler<string>? JobStarted;
     public event EventHandler<string>? JobCompleted;
     public event EventHandler<string>? Logout;
     public event EventHandler<string>? NotificationReceived;
     public event MessageReceivedEventHandler? MessageReceived;
-    public delegate Task MessageReceivedEventHandler(object sender, MessageReceivedEventArgs e);
 
     public class MessageReceivedEventArgs : EventArgs
     {
@@ -92,6 +101,7 @@ public class HubClient : IAsyncDisposable
             UserId = userId;
             Message = message;
         }
+
         public string UserId { get; set; }
         public string Message { get; set; }
     }

--- a/src/Infrastructure/Hubs/HubClient.cs
+++ b/src/Infrastructure/Hubs/HubClient.cs
@@ -49,8 +49,8 @@ public class HubClient : IAsyncDisposable
     }
     public async Task StartAsync(CancellationToken cancellation = default)
     {
-        if (_hubConnection.State != HubConnectionState.Disconnected)
-            throw new ApplicationException("Connection is in progress or has already been established");
+        //if (_hubConnection.State != HubConnectionState.Disconnected)
+        //    throw new ApplicationException("Connection is in progress or has already been established");
         if (_started) return;
         _started = true;
         await _hubConnection.StartAsync(cancellation);

--- a/src/Infrastructure/Hubs/HubClient.cs
+++ b/src/Infrastructure/Hubs/HubClient.cs
@@ -12,12 +12,10 @@ public class HubClient : IAsyncDisposable
     private readonly HubConnection _hubConnection;
     private bool _started;
 
-    public HubClient(NavigationManager navigationManager,
-        AccessTokenProvider authProvider
-    )
+    public HubClient(NavigationManager navigationManager, AccessTokenProvider authProvider)
     {
-        string? token = authProvider.AccessToken;
-        string hubUrl = navigationManager.BaseUri.TrimEnd('/') + SignalR.HubUrl;
+        var token = authProvider.AccessToken;
+        var hubUrl = navigationManager.BaseUri.TrimEnd('/') + SignalR.HubUrl;
         _hubConnection = new HubConnectionBuilder()
             .WithUrl(hubUrl, options =>
             {
@@ -26,33 +24,22 @@ public class HubClient : IAsyncDisposable
             })
             .Build();
         _hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
-        _hubConnection.On<string>(SignalR.OnConnect, userId =>
-        {
-            Login?.Invoke(this, userId);
-        });
+        _hubConnection.On<string>(SignalR.OnConnect, userId => { Login?.Invoke(this, userId); });
 
-        _hubConnection.On<string>(SignalR.OnDisconnect, userId =>
-        {
-            Logout?.Invoke(this, userId);
-        });
-        _hubConnection.On<string>(SignalR.SendNotification, message =>
-        {
-            NotificationReceived?.Invoke(this, message);
-        });
+        _hubConnection.On<string>(SignalR.OnDisconnect, userId => { Logout?.Invoke(this, userId); });
+        _hubConnection.On<string>(SignalR.SendNotification,
+            message => { NotificationReceived?.Invoke(this, message); });
         _hubConnection.On<string, string>(SignalR.SendMessage, HandleReceiveMessage);
-        _hubConnection.On<string>(SignalR.JobCompleted, message =>
-        {
-            JobCompleted?.Invoke(this, message);
-        });
-        _hubConnection.On<string>(SignalR.JobStart, message =>
-        {
-            JobStarted?.Invoke(this, message);
-        });
+        _hubConnection.On<string>(SignalR.JobCompleted, message => { JobCompleted?.Invoke(this, message); });
+        _hubConnection.On<string>(SignalR.JobStart, message => { JobStarted?.Invoke(this, message); });
     }
 
     public async ValueTask DisposeAsync()
     {
-        try { await _hubConnection.StopAsync(); }
+        try
+        {
+            await _hubConnection.StopAsync();
+        }
         finally
         {
             await _hubConnection.DisposeAsync();
@@ -61,10 +48,7 @@ public class HubClient : IAsyncDisposable
 
     public async Task StartAsync(CancellationToken cancellation = default)
     {
-        if (_started)
-        {
-            return;
-        }
+        if (_started) return;
 
         _started = true;
         await _hubConnection.StartAsync(cancellation);

--- a/src/Infrastructure/Hubs/SignalRHub.cs
+++ b/src/Infrastructure/Hubs/SignalRHub.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using CleanArchitecture.Blazor.Infrastructure.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -13,6 +14,7 @@ public interface ISignalRHub
     Task Start(string message);
     Task Completed(string message);
     Task SendMessage(string from,string message);
+    Task SendMessage(string from,string to, string message);
     Task Disconnect(string userId);
     Task Connect(string userId);
     Task SendNotification(string message);
@@ -47,6 +49,11 @@ public class SignalRHub : Hub<ISignalRHub>
     {
         var userName = Context.User?.Identity?.Name ?? string.Empty;
         await Clients.All.SendMessage(userName, message);
+    }
+    public async Task SendMessage(string to,string message)
+    {
+        var userId = Context.User?.GetUserId() ?? string.Empty;
+        await Clients.User(to).SendMessage(userId, message);
     }
     public async Task SendNotification(string message)
     {

--- a/src/Infrastructure/Hubs/SignalRHub.cs
+++ b/src/Infrastructure/Hubs/SignalRHub.cs
@@ -52,8 +52,8 @@ public class SignalRHub : Hub<ISignalRHub>
     }
     public async Task SendMessage(string to,string message)
     {
-        var userId = Context.User?.GetUserId() ?? string.Empty;
-        await Clients.User(to).SendMessage(userId, message);
+        var userName = Context.User?.Identity?.Name ?? string.Empty;
+        await Clients.User(to).SendMessage(userName, message);
     }
     public async Task SendNotification(string message)
     {

--- a/src/Infrastructure/Hubs/SignalRHub.cs
+++ b/src/Infrastructure/Hubs/SignalRHub.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using CleanArchitecture.Blazor.Infrastructure.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -13,52 +12,60 @@ public interface ISignalRHub
 {
     Task Start(string message);
     Task Completed(string message);
-    Task SendMessage(string from,string message);
-    Task SendMessage(string from,string to, string message);
+    Task SendMessage(string from, string message);
+    Task SendMessage(string from, string to, string message);
     Task Disconnect(string userId);
     Task Connect(string userId);
     Task SendNotification(string message);
 }
+
 [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
 public class SignalRHub : Hub<ISignalRHub>
 {
     private static readonly ConcurrentDictionary<string, string> OnlineUsers = new();
+
     public override async Task OnConnectedAsync()
     {
-        var id = Context.ConnectionId;
-        var userName = Context.User?.Identity?.Name ?? string.Empty;
+        string id = Context.ConnectionId;
+        string username = Context.User?.Identity?.Name ?? string.Empty;
         if (!OnlineUsers.ContainsKey(id))
         {
-            OnlineUsers.TryAdd(id, userName);
+            OnlineUsers.TryAdd(id, username);
         }
-        await Clients.All.Connect(userName);
+
+        await Clients.All.Connect(username);
         await base.OnConnectedAsync();
     }
 
     public override async Task OnDisconnectedAsync(Exception? exception)
     {
-        var id = Context.ConnectionId;
+        string id = Context.ConnectionId;
         //try to remove key from dictionary
-        if (OnlineUsers.TryRemove(id, out string? userName))
+        if (OnlineUsers.TryRemove(id, out string? username))
         {
-            await Clients.All.Disconnect(userName);
+            await Clients.All.Disconnect(username);
         }
+
         await base.OnConnectedAsync();
     }
+
     public async Task SendMessage(string message)
     {
-        var userName = Context.User?.Identity?.Name ?? string.Empty;
-        await Clients.All.SendMessage(userName, message);
+        string username = Context.User?.Identity?.Name ?? string.Empty;
+        await Clients.All.SendMessage(username, message);
     }
-    public async Task SendMessage(string to,string message)
+
+    public async Task SendMessage(string to, string message)
     {
-        var userName = Context.User?.Identity?.Name ?? string.Empty;
-        await Clients.User(to).SendMessage(userName, message);
+        string username = Context.User?.Identity?.Name ?? string.Empty;
+        await Clients.User(to).SendMessage(username, message);
     }
+
     public async Task SendNotification(string message)
     {
         await Clients.All.SendNotification(message);
     }
+
     public async Task Completed(string message)
     {
         await Clients.All.Completed(message);


### PR DESCRIPTION
- [x] register DI Scoped instead of  Transient for HubClient.

I'm planning to add some new features to the Notification Service. Specifically, I'm thinking about developing a simple online chat or messaging feature using SignalR. Recently, I've been working on a personal project related to approval workflows for various types of requests. Currently, we're using email notifications to keep everyone informed of the latest status updates. However, I think it would be a great idea to integrate the notification content and any outstanding messages into the system itself.
Of course, I know that the real challenge here isn't developing the SignalR service, but rather designing the UI for the front-end. Do you have any good ideas for how we could approach this?