### PR TITLE
Privacy feature for logging client information

### DIFF
--- a/src/Application/Common/Configurations/PrivacySettings.cs
+++ b/src/Application/Common/Configurations/PrivacySettings.cs
@@ -1,0 +1,9 @@
+namespace CleanArchitecture.Blazor.Application.Common.Configurations;
+
+public class PrivacySettings
+{
+    public const string Privacy = "Privacy";
+    
+    public bool LogClientIpAddresses { get; set; } = true;
+    public bool LogClientAgents { get; set; } = true;
+}

--- a/src/Blazor.Server.UI/appsettings.json
+++ b/src/Blazor.Server.UI/appsettings.json
@@ -3,10 +3,6 @@
   "DatabaseSettings": {
     "DBProvider": "sqlite",
     "ConnectionString": "Data Source=BlazorDashboardDb.db"
-    //"DBProvider": "mssql",
-    //"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=BlazorDashboardDb;Trusted_Connection=True;MultipleActiveResultSets=true;"
-    //"DBProvider": "postgresql",
-    //"ConnectionString": "Server=127.0.0.1;Database=BlazorDashboardDb;User Id=postgres;Password=postgrespw;Port=32768"
   },
   "Logging": {
     "LogLevel": {
@@ -45,6 +41,10 @@
     "UsePickupDirectory": false,
     "MailPickupDirectory": "",
     "SocketOptions": null
+  },
+  "Privacy" : {
+    "LogClientIpAddresses": true,
+    "LogClientAgents" : true
   },
   "Serilog": {
     "MinimumLevel": {

--- a/src/Blazor.Server.UI/appsettings.json
+++ b/src/Blazor.Server.UI/appsettings.json
@@ -3,6 +3,10 @@
   "DatabaseSettings": {
     "DBProvider": "sqlite",
     "ConnectionString": "Data Source=BlazorDashboardDb.db"
+    //"DBProvider": "mssql",
+    //"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=BlazorDashboardDb;Trusted_Connection=True;MultipleActiveResultSets=true;"
+    //"DBProvider": "postgresql",
+    //"ConnectionString": "Server=127.0.0.1;Database=BlazorDashboardDb;User Id=postgres;Password=postgrespw;Port=32768"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Privacy feature for logging client information

This pull request adds support for dynamically setting whether the server should include client IP addresses and/or client agents.

If someone decides they want to use this code base, but don't want to log certain privacy-sensitive information, they can decide to either turn both options off or switch a certain option off. 

This may help people who are publicly using his application in the sense of many administrators and don't want their server to log client-sensitive information.

- `LogClientIpAddresses`: When disabled won't include the client IP address within the logging system.
- `LogClientAgents`: When disabled won't include the client's agent within the logging system.

Besides the above, this also fixes #391 

### Screenshots:

Privacy Settings:

![image](https://github.com/neozhu/CleanArchitectureWithBlazorServer/assets/70259613/2fb9c5bb-3448-4c87-bfc8-fbaae0826233)

Logging settings enabled vs disabled:

![image](https://github.com/neozhu/CleanArchitectureWithBlazorServer/assets/70259613/4be9d063-98e5-4490-93e3-378113f9dcc7)


### Side Note
Refer to commenting in JSON files, because if you don't have to proper tools installed it will throw errors, which would be confusing for someone who freshly clones this project. See the error below:

`JSON standard does not allow comments. Use JSMin or similar tool to remove comments before parsing.`