### PR TITLE
Added Configuration Documentation

### DIFF
--- a/src/Application/Common/Configurations/AppConfigurationSettings.cs
+++ b/src/Application/Common/Configurations/AppConfigurationSettings.cs
@@ -3,12 +3,38 @@
 
 namespace CleanArchitecture.Blazor.Application.Common.Configurations;
 
+/// <summary>
+///     Configuration wrapper for the app configuration section
+/// </summary>
 public class AppConfigurationSettings
 {
-    public const string SectionName = nameof(AppConfigurationSettings);
-    public string Secret { get; set; }=String.Empty;
-    public bool BehindSSLProxy { get; set; } 
-    public string ProxyIP { get; set; } = String.Empty;
-    public string ApplicationUrl { get; set; } = String.Empty;
+    /// <summary>
+    ///     App configuration key constraint
+    /// </summary>
+    public const string Key = nameof(AppConfigurationSettings);
+    
+    /// <summary>
+    ///     Contains the application secret, used for signing
+    /// </summary>
+    public string Secret { get; set; } = string.Empty;
+    
+    /// <summary>
+    ///     Undocumented
+    /// </summary>
+    public bool BehindSSLProxy { get; set; }
+    
+    /// <summary>
+    ///     Undocumented
+    /// </summary>
+    public string ProxyIP { get; set; } = string.Empty;
+    
+    /// <summary>
+    ///     Undocumented
+    /// </summary>
+    public string ApplicationUrl { get; set; } = string.Empty;
+    
+    /// <summary>
+    ///     Undocumented
+    /// </summary>
     public bool Resilience { get; set; }
 }

--- a/src/Application/Common/Configurations/DashbordSettings.cs
+++ b/src/Application/Common/Configurations/DashbordSettings.cs
@@ -3,16 +3,51 @@
 
 namespace CleanArchitecture.Blazor.Application.Common.Configurations;
 
+/// <summary>
+///     Configuration wrapper for the dashboard section
+/// </summary>
 public class DashboardSettings
 {
-    public const string SectionName = nameof(DashboardSettings);
+    /// <summary>
+    ///     Dashboard key constraint
+    /// </summary>
+    public const string Key = nameof(DashboardSettings);
 
-    public string Version { get; set; } = "6.0.2";
-    public string App { get; set; } = "Dashboard";
-    public string AppName { get; set; } = "Admin Dashboard";
-    public string AppFlavor { get; set; } = String.Empty;
-    public string AppFlavorSubscript { get; set; } = String.Empty;
+    /// <summary>
+    ///     Current application version
+    /// </summary>
+    public string Version { get; set; } = "1.3.0";
+    
+    /// <summary>
+    ///     Application framework
+    /// </summary>
+    
+    public string App { get; set; } = "Blazor";
+    
+    /// <summary>
+    ///     The application name / title
+    /// </summary>
+    public string AppName { get; set; } = "Blazor Dashboard";
+    
+    /// <summary>
+    ///     Application framework including the version
+    /// </summary>
+    
+    public string AppFlavor { get; set; } = "Blazor .NET 7.0";
+    
+    /// <summary>
+    ///     Application .NET version
+    /// </summary>
+    public string AppFlavorSubscript { get; set; } = ".NET 7";
+    
+    /// <summary>
+    ///     The name of the company
+    /// </summary>
     public string Company { get; set; } = "Company";
+    
+    /// <summary>
+    ///     Copyright watermark
+    /// </summary>
     public string Copyright { get; set; } = "@2023 Copyright";
  
 }

--- a/src/Application/Common/Configurations/DatabaseSettings.cs
+++ b/src/Application/Common/Configurations/DatabaseSettings.cs
@@ -1,12 +1,32 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
 namespace CleanArchitecture.Blazor.Application.Common.Configurations;
+
+/// <summary>
+///     Configuration wrapper for the database section
+/// </summary>
 public class DatabaseSettings: IValidatableObject
 {
-    public const string SectionName = nameof(DatabaseSettings);
+    /// <summary>
+    ///     Database key constraint
+    /// </summary>
+    public const string Key = nameof(DatabaseSettings);
+    
+    /// <summary>
+    ///     Represents the database provider, which to connect to
+    /// </summary>
     public string DBProvider { get; set; } = string.Empty;
+    
+    /// <summary>
+    ///     The connection string being used to connect with the given database provider
+    /// </summary>
     public string ConnectionString { get; set; } = string.Empty;
 
+    /// <summary>
+    ///     Validates the entered configuration
+    /// </summary>
+    /// <param name="validationContext">Describes the context in which a validation check is performed.</param>
+    /// <returns>The result of the validation</returns>
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (string.IsNullOrEmpty(DBProvider))

--- a/src/Application/Common/Configurations/PrivacySettings.cs
+++ b/src/Application/Common/Configurations/PrivacySettings.cs
@@ -1,9 +1,22 @@
 namespace CleanArchitecture.Blazor.Application.Common.Configurations;
 
+/// <summary>
+///     Configuration wrapper for the privacy section
+/// </summary>
 public class PrivacySettings
 {
-    public const string Privacy = "Privacy";
+    /// <summary>
+    ///     Privacy key constraint
+    /// </summary>
+    public const string Key = nameof(PrivacySettings);
     
+    /// <summary>
+    ///     When enabled, the logs will include client IP addresses
+    /// </summary>
     public bool LogClientIpAddresses { get; set; } = true;
+    
+    /// <summary>
+    ///     When enabled, the logs will include the client agents
+    /// </summary>
     public bool LogClientAgents { get; set; } = true;
 }

--- a/src/Blazor.Server.UI/appsettings.json
+++ b/src/Blazor.Server.UI/appsettings.json
@@ -25,7 +25,7 @@
     "Resilience": false
   },
   "DashboardSettings": {
-    "Version": "7.0.1",
+    "Version": "1.3.0",
     "App": "Blazor",
     "AppName": "Blazor Dashboard",
     "AppFlavor": "Blazor .NET 7.0",
@@ -46,7 +46,7 @@
     "MailPickupDirectory": "",
     "SocketOptions": null
   },
-  "Privacy" : {
+  "PrivacySettings" : {
     "LogClientIpAddresses": true,
     "LogClientAgents" : true
   },

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -16,9 +16,9 @@ public static class DependencyInjection
     public static IServiceCollection AddInfrastructureServices(this IServiceCollection services,
         IConfiguration configuration)
     {
-        services.Configure<DashboardSettings>(configuration.GetSection(DashboardSettings.SectionName));
-        services.Configure<DatabaseSettings>(configuration.GetSection(DatabaseSettings.SectionName));
-        services.Configure<AppConfigurationSettings>(configuration.GetSection(AppConfigurationSettings.SectionName));
+        services.Configure<DashboardSettings>(configuration.GetSection(DashboardSettings.Key));
+        services.Configure<DatabaseSettings>(configuration.GetSection(DatabaseSettings.Key));
+        services.Configure<AppConfigurationSettings>(configuration.GetSection(AppConfigurationSettings.Key));
         services.AddSingleton(s => s.GetRequiredService<IOptions<DashboardSettings>>().Value);
         services.AddSingleton(s => s.GetRequiredService<IOptions<DatabaseSettings>>().Value);
         services.AddSingleton(s => s.GetRequiredService<IOptions<AppConfigurationSettings>>().Value);

--- a/src/Infrastructure/Extensions/SerilogExtensions.cs
+++ b/src/Infrastructure/Extensions/SerilogExtensions.cs
@@ -71,7 +71,7 @@ public static class SerilogExtensions
 
     private static void EnrichWithClientInfo(LoggerConfiguration serilogConfig, IConfiguration configuration)
     {
-        var privacySettings = configuration.GetRequiredSection(PrivacySettings.Privacy).Get<PrivacySettings>();
+        var privacySettings = configuration.GetRequiredSection(PrivacySettings.Key).Get<PrivacySettings>();
 
         if (privacySettings == null) return;
         if (privacySettings.LogClientIpAddresses) serilogConfig.Enrich.WithClientIp();


### PR DESCRIPTION
- [x] Added: Configuration Documentation
- [x] Made the Privacy settings sync with the structure of the rest of the configuration

A few settings are marked as undocumented since I don't feel like I have a good idea of what those options are doing, so I hope you are able to document those. 

In general, we might want to spend some time documenting certain methods, as currently nothing is documented, which makes it really hard for new contributors like myself may have a hard time understanding certain pieces of the code. 

Adding `///` above a method will automatically generate a documentation template, which you only have to fill in. This will extremely help new contributors to understand the structure of the code since when using `///` it will enable the hover documentation, which you normally get when hovering over a method. 

`///` documentation example: 

![image](https://github.com/neozhu/CleanArchitectureWithBlazorServer/assets/70259613/176aa2f0-c448-4de4-9378-fc8ec5bd7770)
