### PR TITLE
remove Duende.IdentityServer packages

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -9,8 +9,9 @@
     <ItemGroup>
         
         <PackageReference Include="Hangfire.AspNetCore" Version="1.8.2" />
-        
+ 
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="7.0.5" />
@@ -27,11 +28,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.5" />
-        <PackageReference Include="Duende.IdentityServer" Version="6.3.1" />
-        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="6.3.1" />
-        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="6.3.1" />
-        <PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="6.3.1" />
-        <PackageReference Include="Duende.IdentityServer.Storage" Version="6.3.1" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
         <PackageReference Include="Polly" Version="7.2.3" />
         <PackageReference Include="QuestPDF" Version="2023.5.1" />

--- a/src/Infrastructure/Services/CircuitHandlerService.cs
+++ b/src/Infrastructure/Services/CircuitHandlerService.cs
@@ -1,4 +1,3 @@
-using Duende.IdentityServer.Extensions;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 
 namespace CleanArchitecture.Blazor.Infrastructure.Services;
@@ -18,7 +17,7 @@ public class CircuitHandlerService : CircuitHandler
         CancellationToken cancellationToken)
     {
         var state = await _authenticationStateProvider.GetAuthenticationStateAsync();
-        if (state is not null && state.User.IsAuthenticated() && state.User.Identity is not null)
+        if (state is not null && state.User.Identity is not null && state.User.Identity.IsAuthenticated)
         {
             _usersStateContainer.Update(circuit.Id, state.User.Identity.Name);
         }


### PR DESCRIPTION
remove:
```c#
<PackageReference Include="Duende.IdentityServer" Version="6.3.1" />
<PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="6.3.1" />
<PackageReference Include="Duende.IdentityServer.EntityFramework" Version="6.3.1" />
<PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="6.3.1" />
<PackageReference Include="Duende.IdentityServer.Storage" Version="6.3.1" />
```
add:
```c#
<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.5" />
```
fixed:
state.User.Identity.IsAuthenticated instead of state.User.IsAuthenticated()