### PR TITLE
Updated: Packages and LogEventLevel for MudBlazor

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="11.5.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
-      <PackageReference Include="Fluxor.Blazor.Web" Version="5.8.0" />
-      <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="5.8.0" />
+      <PackageReference Include="Fluxor.Blazor.Web" Version="5.9.0" />
+      <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="5.9.0" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" />

--- a/src/Blazor.Server.UI/Blazor.Server.UI.csproj
+++ b/src/Blazor.Server.UI/Blazor.Server.UI.csproj
@@ -10,12 +10,12 @@
       <UserSecretsId>8118d19e-a6db-4446-bdb6-fa62b17f843d</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-        <PackageReference Include="Blazor-Analytics" Version="3.11.0" />
+        <PackageReference Include="Blazor-Analytics" Version="3.12.0" />
         <PackageReference Include="Blazor-ApexCharts" Version="0.9.21-beta" />
         <PackageReference Include="BlazorDownloadFile" Version="2.4.0.2" />
         <PackageReference Include="BlazorTime" Version="1.0.3" />
        <PackageReference Include="CodeBeam.MudBlazor.Extensions" Version="6.5.0.2" />
-       <PackageReference Include="MudBlazor" Version="6.3.0" />
+       <PackageReference Include="MudBlazor" Version="6.4.1" />
        <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Infrastructure/Extensions/SerilogExtensions.cs
+++ b/src/Infrastructure/Extensions/SerilogExtensions.cs
@@ -24,6 +24,7 @@ public static class SerilogExtensions
             configuration.ReadFrom.Configuration(context.Configuration)
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Error)
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Error)
+                .MinimumLevel.Override("MudBlazor", LogEventLevel.Information)
                 .MinimumLevel.Override("Serilog", LogEventLevel.Error)
                 .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Update", LogEventLevel.Error)
                 .MinimumLevel.Override("Hangfire.BackgroundJobServer", LogEventLevel.Error)

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -31,12 +31,12 @@
         <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
         <PackageReference Include="Polly" Version="7.2.3" />
-        <PackageReference Include="QuestPDF" Version="2023.5.1" />
+        <PackageReference Include="QuestPDF" Version="2023.5.2" />
         <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="6.3.0" />
         <PackageReference Include="Serilog.Sinks.Postgresql.Alternative" Version="3.5.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.2.0" />
+        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Hangfire.InMemory" Version="0.4.1" />
         <PackageReference Include="Serilog.Sinks.SQLite" Version="6.0.0" />

--- a/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
+++ b/tests/Application.IntegrationTests/Application.IntegrationTests.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Includes the bug fix in MudBlazor version `6.4.1` for the PopoverService bug which occurred in version `6.4.0`.

Updated: Minimum log level for MudBlazor to `LogEventLevel.Information` as since version `6.4.0` they added debug logging to the [ObserverManager.cs](https://github.com/MudBlazor/MudBlazor/blob/dev/src/MudBlazor/Utilities/ObserverManager/ObserverManager.cs) file.

### Showcase of the new MudBlazor ObserverManager logging messages


![](https://user-images.githubusercontent.com/70259613/244412808-2ccbc809-fb2f-4ba4-af16-15793657a79a.png)
