### PR TITLE
Added: Google Analytics Configurator

### DIFF
--- a/CleanArchitecture.Blazor.nuspec
+++ b/CleanArchitecture.Blazor.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>CleanArchitecture.Blazor.Solution.Template</id>
-    <version>1.0.0-preview.5</version>
+    <version>1.0.0-preview.6</version>
     <title>Clean Architecture Blazor Solution Template</title>
     <authors>hl.z</authors>
     <description>Clean Architecture Blazor Solution Template for .NET 7.</description>
@@ -10,8 +10,8 @@
       A Clean Architecture Blazor Server Solution Template for creating a Single-Page Application (SPA) with ASP.NET Core.
     </summary>
     <releaseNotes>
-      1.0.0-preview.5
-      - ♻️ recycle(Infrastructure): Switch events dispatcher to interceptor.
+      1.0.0-preview.6
+      - Made Google Analytics configurable.
      </releaseNotes>
 
     <projectUrl>https://github.com/neozhu/CleanArchitectureWithBlazorServer</projectUrl>

--- a/src/Application/Common/Configurations/PrivacySettings.cs
+++ b/src/Application/Common/Configurations/PrivacySettings.cs
@@ -1,22 +1,36 @@
 namespace CleanArchitecture.Blazor.Application.Common.Configurations;
 
 /// <summary>
-///     Configuration wrapper for the privacy section
+///     Represents the privacy settings for the application.
 /// </summary>
 public class PrivacySettings
 {
     /// <summary>
-    ///     Privacy key constraint
+    ///     Gets the unique key to identify the PrivacySettings configuration.
     /// </summary>
     public const string Key = nameof(PrivacySettings);
-    
+
     /// <summary>
-    ///     When enabled, the logs will include client IP addresses
+    ///     Gets or sets a value indicating whether the client IP addresses should be logged.
     /// </summary>
     public bool LogClientIpAddresses { get; set; } = true;
-    
+
     /// <summary>
-    ///     When enabled, the logs will include the client agents
+    ///     Gets or sets a value indicating whether the client agents (user agents) should be logged.
     /// </summary>
     public bool LogClientAgents { get; set; } = true;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether Google Analytics should be used for tracking.
+    /// </summary>
+    public bool UseGoogleAnalytics { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the Google Analytics tracking key.
+    /// </summary>
+    /// <remarks>
+    ///     If <see cref="UseGoogleAnalytics" /> is set to true, this property must contain a valid Google Analytics tracking
+    ///     key.
+    /// </remarks>
+    public string? GoogleAnalyticsKey { get; set; }
 }

--- a/src/Blazor.Server.UI/Program.cs
+++ b/src/Blazor.Server.UI/Program.cs
@@ -5,14 +5,14 @@ using CleanArchitecture.Blazor.Infrastructure;
 using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Http.Connections;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
 
 builder.RegisterSerilog();
-builder.Services.AddBlazorUiServices();
+builder.AddBlazorUiServices();
 builder.Services.AddInfrastructureServices(builder.Configuration)
     .AddApplicationServices();
 
-WebApplication app = builder.Build();
+var app = builder.Build();
 
 app.MapHealthChecks("/health");
 app.UseExceptionHandler("/Error");
@@ -24,12 +24,12 @@ app.MapBlazorHub(options => options.Transports = HttpTransportType.WebSockets);
 if (app.Environment.IsDevelopment())
 {
     // Initialise and seed database
-    using (IServiceScope scope = app.Services.CreateScope())
+    using (var scope = app.Services.CreateScope())
     {
-        ApplicationDbContextInitializer initializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
+        var initializer = scope.ServiceProvider.GetRequiredService<ApplicationDbContextInitializer>();
         await initializer.InitialiseAsync();
         await initializer.SeedAsync();
-        INotificationService? notificationService = scope.ServiceProvider.GetService<INotificationService>();
+        var notificationService = scope.ServiceProvider.GetService<INotificationService>();
         if (notificationService is InMemoryNotificationService inMemoryNotificationService)
         {
             inMemoryNotificationService.Preload();

--- a/src/Blazor.Server.UI/appsettings.json
+++ b/src/Blazor.Server.UI/appsettings.json
@@ -46,9 +46,11 @@
     "MailPickupDirectory": "",
     "SocketOptions": null
   },
-  "PrivacySettings" : {
+  "PrivacySettings": {
     "LogClientIpAddresses": true,
-    "LogClientAgents" : true
+    "LogClientAgents": true,
+    "UseGoogleAnalytics": false,
+    "GoogleAnalyticsKey": ""
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
As requested in #451, users now have the ability to configure whether they want to use Google Analytics or not. By default, Google Analytics is disabled, and users can enable it through the `appsettings.json`.

The `PrivacySettings` class has been modified to support this feature with the following properties:

- `UseGoogleAnalytics`: A boolean that indicates whether Google Analytics should be enabled (`true`) or not (`false`).
- `GoogleAnalyticsKey`: A nullable string that holds the Google Analytics key when `UseGoogleAnalytics` is set to `true`. When Google Analytics is disabled, this property can be empty.

These changes allow users to have better control over Google Analytics integration, ensuring their privacy preferences are respected.

Updated configuration section:
```json
"PrivacySettings": {
    "LogClientIpAddresses": true,
    "LogClientAgents": true,
    "UseGoogleAnalytics": false,
    "GoogleAnalyticsKey": ""
  },
```

Updated PrivacySettings class:
```csharp
/// <summary>
///     Represents the privacy settings for the application.
/// </summary>
public class PrivacySettings
{
    /// <summary>
    ///     Gets the unique key to identify the PrivacySettings configuration.
    /// </summary>
    public const string Key = nameof(PrivacySettings);

    /// <summary>
    ///     Gets or sets a value indicating whether the client IP addresses should be logged.
    /// </summary>
    public bool LogClientIpAddresses { get; set; } = true;

    /// <summary>
    ///     Gets or sets a value indicating whether the client agents (user agents) should be logged.
    /// </summary>
    public bool LogClientAgents { get; set; } = true;

    /// <summary>
    ///     Gets or sets a value indicating whether Google Analytics should be used for tracking.
    /// </summary>
    public bool UseGoogleAnalytics { get; set; }

    /// <summary>
    ///     Gets or sets the Google Analytics tracking key.
    /// </summary>
    /// <remarks>
    ///     If <see cref="UseGoogleAnalytics" /> is set to true, this property must contain a valid Google Analytics tracking
    ///     key.
    /// </remarks>
    public string? GoogleAnalyticsKey { get; set; }
}
```