### PR TITLE
Restore Logging of Client Agents: Fix for Breaking Change in Serilog.Enrichers.ClientInfo v2.0.0

### DIFF
--- a/src/Infrastructure/Extensions/SerilogExtensions.cs
+++ b/src/Infrastructure/Extensions/SerilogExtensions.cs
@@ -76,6 +76,7 @@ public static class SerilogExtensions
 
         if (privacySettings == null) return;
         if (privacySettings.LogClientIpAddresses) serilogConfig.Enrich.WithClientIp();
+        if (privacySettings.LogClientAgents) serilogConfig.Enrich.WithRequestHeader("User-Agent");
 
     }
 


### PR DESCRIPTION
**Pull Request to Restore Logging of Client Agents**

This pull request aims to address a breaking change introduced in version `2.0.0` of the `Serilog.Enrichers.ClientInfo` NuGet package. The change affected the way client user agents were retrieved, leading to their absence in the logs, despite having privacy settings enabled for logging user agents.

Previously, to obtain client user agents, the configuration used to be set as follows:
```csharp
serilogConfig.Enrich.WithClientAgent();
```

However, with the new version, the approach to retrieve user agents has been updated, and now it requires the following configuration:
```csharp
serilogConfig.Enrich.WithRequestHeader("User-Agent");
```

The issue was discovered by @neozhu, who noticed that the logging of client agents was no longer functioning as expected. Upon investigation, it was found that the line responsible for enabling the logging of client agents was inadvertently removed during an update to the resource files. This unintentional change slipped through the review process since it wasn't immediately apparent.

This pull request aims to restore the ability to log client agents by adding back the necessary configuration to enable the logging of user agents.

With this fix, the logs will once again capture valuable client agent information, providing valuable insights and analytics. The privacy settings will continue to be respected while ensuring that essential client agent data is properly logged.

Let's merge this pull request to reinstate the logging of client agents and maintain a comprehensive and accurate log record.