### PR TITLE
Updates to loading screen, check dashboard settings

### DIFF
--- a/src/Blazor.Server.UI/App.razor
+++ b/src/Blazor.Server.UI/App.razor
@@ -1,51 +1,96 @@
 @using Blazor.Server.UI.Services.Layout
-@inject IStringLocalizer<SharedResource> L
-<Fluxor.Blazor.Web.StoreInitializer/>
-<LoadingScreen LayoutService="LayoutService" LoadingDelayMs="@(Settings.EnableLoadingScreen ? Settings.LoadingScreenDuration : 0)">
-    <CascadingAuthenticationState>
-        <Router AppAssembly="@typeof(App).Assembly">
-            <Found Context="routeData">
-                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                    <Authorizing>
-                        <text>@L["Please wait, we are authorizing you..."]</text>
-                    </Authorizing>
-                    <NotAuthorized>
-                        @if (context.User.Identity?.IsAuthenticated ?? false)
-                        {
-                            <p>@L["You are not authorized to be here. For more information, contact your system administrator."]</p>
-                        }
-                        else
-                        {
-                            <Login/>
-                        }
-                    </NotAuthorized>
-                </AuthorizeRouteView>
 
-            </Found>
-            <NotFound>
-                <PageTitle>Not found</PageTitle>
-                <LayoutView Layout="@typeof(MainLayout)">
-                    <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="d-flex">
-                        <p role="alert">
-                            @L["Sorry, there's nothing at this address."] <MudButton Variant="Variant.Filled" Size="Size.Small" Link="/">@L["Go Home"]</MudButton>
-                        </p>
-                    </MudContainer>
-                </LayoutView>
-            </NotFound>
-        </Router>
-    </CascadingAuthenticationState>
+@inject IStringLocalizer<SharedResource> L
+@inject NavigationManager NavManager
+
+<Fluxor.Blazor.Web.StoreInitializer />
+
+<LoadingScreen IsLoaded="@_isLoaded" LayoutService="LayoutService">
+    <div class="page-transition @transitionClass">
+        <CascadingAuthenticationState>
+            <Router AppAssembly="@typeof(App).Assembly">
+                <Found Context="routeData">
+                    <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                        <Authorizing>
+                            <text>@L["Please wait, we are authorizing you..."]</text>
+                        </Authorizing>
+                        <NotAuthorized>
+                            @if (@context.User.Identity?.IsAuthenticated ?? false)
+                            {
+                                <p>@L["You are not authorized to be here. For more information, contact your system administrator."]</p>
+                            }
+                            else
+                            {
+                                <Login/>
+                            }
+                        </NotAuthorized>
+                    </AuthorizeRouteView>
+
+                </Found>
+                <NotFound>
+                    <PageTitle>Not found</PageTitle>
+                    <LayoutView Layout="@typeof(MainLayout)">
+                        <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="d-flex">
+                            <p role="alert">@L["Sorry, there's nothing at this address."] <MudButton Variant="Variant.Filled" Size="Size.Small" Link="/">@L["Go Home"]</MudButton></p>
+                        </MudContainer>
+                    </LayoutView>
+                </NotFound>
+            </Router>
+        </CascadingAuthenticationState>
+    </div>
 </LoadingScreen>
 
 @code{
-
-    [Inject]
-    private LayoutService LayoutService { get; set; }
-
+    [Inject] private LayoutService LayoutService { get; set; }
+    private string transitionClass = "loadScreen-initial-hidden";
+    private bool _isLoaded = true;
+    
     protected override async Task OnInitializedAsync()
     {
-        await base.OnInitializedAsync();
         LayoutService.SetBaseTheme(Theme.Theme.ApplicationTheme());
         await LayoutService.ApplyUserPreferences(true);
+        NavManager.LocationChanged += HandleLocationChanged;
     }
+    
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            if (Settings.EnableLoadingScreen)
+            {
+                transitionClass = ""; 
+                _isLoaded = false;
+                StateHasChanged();
 
+                await Task.Delay(Settings.LoadingScreenDuration >= 0 ? Settings.LoadingScreenDuration : 2000);
+
+                //transitionClass = "loadScreen-fade-in";
+                _isLoaded = true;
+                StateHasChanged();
+            }
+        }
+    }
+    
+    private async void HandleLocationChanged(object sender, LocationChangedEventArgs e)
+    {
+        if (Settings.EnableLoadingScreen)
+        {
+            //transitionClass = "loadScreen-fade-out";
+            transitionClass = "";
+
+            _isLoaded = false;
+            StateHasChanged();
+
+            await Task.Delay(600);
+
+            //transitionClass = "loadScreen-fade-in";
+            _isLoaded = true;
+            StateHasChanged();
+        }
+    }
+    
+    public void Dispose()
+    {
+        NavManager.LocationChanged -= HandleLocationChanged;
+    }
 }

--- a/src/Blazor.Server.UI/Components/Shared/LoadingScreen.razor
+++ b/src/Blazor.Server.UI/Components/Shared/LoadingScreen.razor
@@ -1,7 +1,7 @@
 ﻿@using Blazor.Server.UI.Services.Layout
 @inherits LayoutComponentBase
 
-@if (_isLoaded)
+@if (IsLoaded)
 {
     @ChildContent
 }
@@ -132,17 +132,10 @@ else
 
     [Parameter]
     public LayoutService LayoutService { get; set; }
-    
-    [Parameter]
-    public int LoadingDelayMs { get; set; }
 
-    private bool _isLoaded;
+    [Parameter]
+    public bool IsLoaded { get; set; }
 
     private string Gradient => $"background-image: linear-gradient(-120deg, {(LayoutService.IsDarkMode ? LayoutService.CurrentTheme.PaletteDark.Background : LayoutService.CurrentTheme.Palette.Background)} 50%, {(LayoutService.IsDarkMode ? LayoutService.CurrentTheme.PaletteDark.Surface : LayoutService.CurrentTheme.Palette.Surface)} 50%);";
 
-    protected override async Task OnInitializedAsync()
-    {
-        await Task.Delay(LoadingDelayMs);
-        _isLoaded = true;
-    }
 }

--- a/src/Blazor.Server.UI/wwwroot/css/app.css
+++ b/src/Blazor.Server.UI/wwwroot/css/app.css
@@ -1,1 +1,14 @@
-﻿
+﻿.loadScreen-fade-in {
+    opacity: 1;
+    transition: opacity 0.5s ease-in-out;
+}
+
+.loadScreen-fade-out {
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+.loadScreen-initial-hidden {
+    opacity: 0;
+    visibility: hidden;
+}


### PR DESCRIPTION
In app.razor checked for setting
Component updated to take in IsLoaded, so you can use to block long running tasks in other pages/elements.

The loader will now appear for "first render" duration based on the param setting.  (frist render is full page loads)
I also added example for on navigation change so every page toggle you will see it for small duration.
Nav manager is injected so you could in first render check the page for your auth url and then not show it 2nd time.

I also left comments for a more "basic" screen fade (set the is loaded to true or remove the component from app.razor)
//transitionClass = "loadScreen-fade-out";
transitionClass = "";