### PR TITLE
✨Refactor BaseEntity to Support Multiple Id Types

### DIFF
--- a/src/Application/Features/AuditTrails/DTOs/AuditTrailDto.cs
+++ b/src/Application/Features/AuditTrails/DTOs/AuditTrailDto.cs
@@ -9,7 +9,7 @@ namespace CleanArchitecture.Blazor.Application.Features.AuditTrails.DTOs;
 [Description("Audit Trails")]
 public class AuditTrailDto
 {
-    [Description("Id")] public int Id { get; set; }
+    [Description("Id")] public string Id { get; set; } = Guid.NewGuid().ToString();
 
     [Description("User Id")] public string? UserId { get; set; }
 

--- a/src/Application/Features/Tenants/Commands/AddEdit/AddEditTenantCommand.cs
+++ b/src/Application/Features/Tenants/Commands/AddEdit/AddEditTenantCommand.cs
@@ -57,8 +57,6 @@ public class AddEditTenantCommandHandler : IRequestHandler<AddEditTenantCommand,
         {
             item = _mapper.Map(dto, item);
         }
-
-        item.AddDomainEvent(new UpdatedEvent<Tenant>(item));
         await _context.SaveChangesAsync(cancellationToken);
         return await Result<string>.SuccessAsync(item.Id);
     }

--- a/src/Application/Features/Tenants/Commands/Delete/DeleteTenantCommand.cs
+++ b/src/Application/Features/Tenants/Commands/Delete/DeleteTenantCommand.cs
@@ -41,7 +41,6 @@ public class DeleteTenantCommandHandler :
         var items = await _context.Tenants.Where(x => request.Id.Contains(x.Id)).ToListAsync(cancellationToken);
         foreach (var item in items)
         {
-            item.AddDomainEvent(new UpdatedEvent<Tenant>(item));
             _context.Tenants.Remove(item);
         }
 

--- a/src/Domain/Common/BaseAuditableEntity.cs
+++ b/src/Domain/Common/BaseAuditableEntity.cs
@@ -1,38 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel.DataAnnotations.Schema;
-using CleanArchitecture.Blazor.Domain.Identity;
-
 namespace CleanArchitecture.Blazor.Domain.Common;
-
-public interface IEntity
-{
-
-}
-
-public abstract class BaseEntity: IEntity
-{
-    private readonly List<DomainEvent> _domainEvents = new();
-
-    [NotMapped]
-    public IReadOnlyCollection<DomainEvent> DomainEvents => _domainEvents.AsReadOnly();
-
-    public void AddDomainEvent(DomainEvent domainEvent)
-    {
-        _domainEvents.Add(domainEvent);
-    }
-
-    public void RemoveDomainEvent(DomainEvent domainEvent)
-    {
-        _domainEvents.Remove(domainEvent);
-    }
-
-    public void ClearDomainEvents()
-    {
-        _domainEvents.Clear();
-    }
-}
 
 public abstract class BaseAuditableEntity : BaseEntity
 {
@@ -43,25 +12,4 @@ public abstract class BaseAuditableEntity : BaseEntity
     public virtual DateTime? LastModified { get; set; }
 
     public virtual string? LastModifiedBy { get; set; }
-}
-
-public interface ISoftDelete
-{
-    DateTime? Deleted { get; set; }
-    string? DeletedBy { get; set; }
-}
-public abstract class BaseAuditableSoftDeleteEntity : BaseAuditableEntity, ISoftDelete
-{
-    public DateTime? Deleted { get; set; }
-    public string? DeletedBy { get; set; }
-
-}
-
-
-public abstract class OwnerPropertyEntity: BaseAuditableEntity
-{
-    [ForeignKey("CreatedBy")]
-    public virtual ApplicationUser? Owner { get; set; }
-    [ForeignKey("LastModifiedBy")]
-    public virtual ApplicationUser? Editor { get; set; }
 }

--- a/src/Domain/Common/BaseAuditableSoftDeleteEntity.cs
+++ b/src/Domain/Common/BaseAuditableSoftDeleteEntity.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CleanArchitecture.Blazor.Domain.Common;
+
+public abstract class BaseAuditableSoftDeleteEntity : BaseAuditableEntity, ISoftDelete
+{
+    public DateTime? Deleted { get; set; }
+    public string? DeletedBy { get; set; }
+
+}

--- a/src/Domain/Common/BaseEntity.cs
+++ b/src/Domain/Common/BaseEntity.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace CleanArchitecture.Blazor.Domain.Common;
+
+public abstract class BaseEntity: IEntity<int>
+{
+    public virtual int Id { get; set; }
+    private readonly List<DomainEvent> _domainEvents = new();
+
+    [NotMapped]
+    public IReadOnlyCollection<DomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    public void AddDomainEvent(DomainEvent domainEvent)
+    {
+        _domainEvents.Add(domainEvent);
+    }
+
+    public void RemoveDomainEvent(DomainEvent domainEvent)
+    {
+        _domainEvents.Remove(domainEvent);
+    }
+
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
+}

--- a/src/Domain/Common/IEntity.cs
+++ b/src/Domain/Common/IEntity.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CleanArchitecture.Blazor.Domain.Common;
+
+public interface IEntity
+{
+
+}
+public interface IEntity<T> : IEntity
+{
+    T Id { get; set; }
+}

--- a/src/Domain/Common/ISoftDelete.cs
+++ b/src/Domain/Common/ISoftDelete.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace CleanArchitecture.Blazor.Domain.Common;
+
+public interface ISoftDelete
+{
+    DateTime? Deleted { get; set; }
+    string? DeletedBy { get; set; }
+}

--- a/src/Domain/Common/OwnerPropertyEntity.cs
+++ b/src/Domain/Common/OwnerPropertyEntity.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations.Schema;
+using CleanArchitecture.Blazor.Domain.Identity;
+
+namespace CleanArchitecture.Blazor.Domain.Common;
+
+public abstract class OwnerPropertyEntity: BaseAuditableEntity
+{
+    [ForeignKey("CreatedBy")]
+    public virtual ApplicationUser? Owner { get; set; }
+    [ForeignKey("LastModifiedBy")]
+    public virtual ApplicationUser? Editor { get; set; }
+}

--- a/src/Domain/Entities/Audit/AuditTrail.cs
+++ b/src/Domain/Entities/Audit/AuditTrail.cs
@@ -7,9 +7,9 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace CleanArchitecture.Blazor.Domain.Entities.Audit;
 
-public class AuditTrail : IEntity
+public class AuditTrail : IEntity<string>
 {
-    public int Id { get; set; }
+    public string Id { get; set; } = Guid.NewGuid().ToString();
     public string? UserId { get; set; }
     public virtual ApplicationUser? Owner { get; set; }
     public AuditType AuditType { get; set; }

--- a/src/Domain/Entities/Customer.cs
+++ b/src/Domain/Entities/Customer.cs
@@ -5,7 +5,6 @@ namespace CleanArchitecture.Blazor.Domain.Entities;
 
 public class Customer : BaseAuditableEntity
 {
-    public int Id { get; set; }
     public string? Name { get; set; }
     public string? Description { get; set; }
    

--- a/src/Domain/Entities/Document.cs
+++ b/src/Domain/Entities/Document.cs
@@ -7,7 +7,6 @@ namespace CleanArchitecture.Blazor.Domain.Entities;
 
 public class Document : OwnerPropertyEntity, IMayHaveTenant, IAuditTrial
 {
-    public int Id { get; set; }
     public string? Title { get; set; }
     public string? Description { get; set; }
     public JobStatus Status { get; set; } = default!;

--- a/src/Domain/Entities/KeyValue.cs
+++ b/src/Domain/Entities/KeyValue.cs
@@ -7,7 +7,6 @@ namespace CleanArchitecture.Blazor.Domain.Entities;
 
 public class KeyValue : BaseAuditableEntity, IAuditTrial
 {
-    public int Id { get; set; }
     public Picklist Name { get; set; } = Picklist.Brand;
     public string? Value { get; set; } 
     public string? Text { get; set; } 

--- a/src/Domain/Entities/Logger/Logger.cs
+++ b/src/Domain/Entities/Logger/Logger.cs
@@ -3,7 +3,7 @@
 
 namespace CleanArchitecture.Blazor.Domain.Entities.Logger;
 
-public class Logger : IEntity
+public class Logger : IEntity<int>
 {
     public int Id { get; set; }
     public string? Message { get; set; }

--- a/src/Domain/Entities/Product.cs
+++ b/src/Domain/Entities/Product.cs
@@ -5,7 +5,6 @@ namespace CleanArchitecture.Blazor.Domain.Entities;
 
 public class Product : BaseAuditableEntity
 {
-    public int Id { get; set; }
     public string? Name { get; set; }
     public string? Description { get; set; }
     public string? Brand { get; set; }

--- a/src/Domain/Entities/Tenant.cs
+++ b/src/Domain/Entities/Tenant.cs
@@ -1,5 +1,5 @@
 namespace CleanArchitecture.Blazor.Domain.Entities;
-public class Tenant : BaseAuditableEntity
+public class Tenant : IEntity<string>
 {
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public string? Name { get; set; }

--- a/src/Domain/Events/CreatedEvent.cs
+++ b/src/Domain/Events/CreatedEvent.cs
@@ -3,7 +3,7 @@
 
 
 namespace CleanArchitecture.Blazor.Domain.Events;
-public class CreatedEvent<T> : DomainEvent where T : BaseEntity
+public class CreatedEvent<T> : DomainEvent where T : IEntity
 {
     public CreatedEvent(T entity)
     {

--- a/src/Domain/Events/DeletedEvent.cs
+++ b/src/Domain/Events/DeletedEvent.cs
@@ -3,7 +3,7 @@
 
 
 namespace CleanArchitecture.Blazor.Domain.Events;
-public class DeletedEvent<T> : DomainEvent where T : BaseEntity
+public class DeletedEvent<T> : DomainEvent where T : IEntity
 {
     public DeletedEvent(T entity)
     {

--- a/src/Domain/Events/UpdatedEvent.cs
+++ b/src/Domain/Events/UpdatedEvent.cs
@@ -1,5 +1,5 @@
 namespace CleanArchitecture.Blazor.Domain.Events;
-public class UpdatedEvent<T> : DomainEvent where T : BaseEntity
+public class UpdatedEvent<T> : DomainEvent where T : IEntity
 {
     public UpdatedEvent(T entity)
     {

--- a/src/Infrastructure/Persistence/Configurations/TenantConfiguration.cs
+++ b/src/Infrastructure/Persistence/Configurations/TenantConfiguration.cs
@@ -9,6 +9,6 @@ public class TenantConfiguration : IEntityTypeConfiguration<Tenant>
 {
     public void Configure(EntityTypeBuilder<Tenant> builder)
     {
-        builder.Ignore(e => e.DomainEvents);
+        //builder.Ignore(e => e.DomainEvents);
     }
 }

--- a/src/Migrators/Migrators.SqLite/Migrations/20230825230709_change_AuditTrail_Id_type_to_guid.Designer.cs
+++ b/src/Migrators/Migrators.SqLite/Migrations/20230825230709_change_AuditTrail_Id_type_to_guid.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CleanArchitecture.Blazor.Migrators.SqLite.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230825230709_change_AuditTrail_Id_type_to_guid")]
+    partial class change_AuditTrail_Id_type_to_guid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.10");

--- a/src/Migrators/Migrators.SqLite/Migrations/20230825230709_change_AuditTrail_Id_type_to_guid.cs
+++ b/src/Migrators/Migrators.SqLite/Migrations/20230825230709_change_AuditTrail_Id_type_to_guid.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CleanArchitecture.Blazor.Migrators.SqLite.Migrations
+{
+    /// <inheritdoc />
+    public partial class change_AuditTrail_Id_type_to_guid : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AuditTrails_AspNetUsers_UserId",
+                table: "AuditTrails");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Documents_AspNetUsers_CreatedBy",
+                table: "Documents");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Documents_AspNetUsers_LastModifiedBy",
+                table: "Documents");
+
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedBy",
+                table: "Tenants");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "AuditTrails",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER")
+                .OldAnnotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AuditTrails_AspNetUsers_UserId",
+                table: "AuditTrails",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Documents_AspNetUsers_CreatedBy",
+                table: "Documents",
+                column: "CreatedBy",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Documents_AspNetUsers_LastModifiedBy",
+                table: "Documents",
+                column: "LastModifiedBy",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AuditTrails_AspNetUsers_UserId",
+                table: "AuditTrails");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Documents_AspNetUsers_CreatedBy",
+                table: "Documents");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Documents_AspNetUsers_LastModifiedBy",
+                table: "Documents");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "Tenants",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Tenants",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModified",
+                table: "Tenants",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastModifiedBy",
+                table: "Tenants",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "AuditTrails",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT")
+                .Annotation("Sqlite:Autoincrement", true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AuditTrails_AspNetUsers_UserId",
+                table: "AuditTrails",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Documents_AspNetUsers_CreatedBy",
+                table: "Documents",
+                column: "CreatedBy",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Documents_AspNetUsers_LastModifiedBy",
+                table: "Documents",
+                column: "LastModifiedBy",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
**Description**:

Following suggestions from several developers regarding the need to support common Entity Id types in EntityFramework, such as Guid, String, and Numeric, I've made an attempt to enhance the flexibility while ensuring simplicity.

Traditionally, I've always relied on int auto-increment types as primary keys. This is primarily due to their straightforward nature and ease of sorting. However, to cater to broader needs, this PR introduces a way to seamlessly support other types without a significant overhaul of the existing project.

**Changes Made**:

1. Introduced a new interface `IEntity<T>` inheriting from `IEntity`:
```csharp
public interface IEntity<T> : IEntity
{
    T Id { get; set; }
}
```

2. Refactored `BaseEntity` to inherit from `IEntity<T>`, specifying the desired primary key type:
```csharp
public abstract class BaseEntity: IEntity<int>
{
    public virtual int Id { get; set; }
    //... other properties and methods as before
}
```

To use a different type like `string` for the Id, simply modify the `BaseEntity` class definition to `IEntity<string>`. Remember to run the `add-migration` command afterward. 

**Note**: It's advisable not to change the primary key type mid-project development.

---

This description offers a clear and concise explanation of the changes you've made. Remember to adjust as needed, depending on your project's PR review process and conventions.