### PR TITLE
Adding identity password settings to appsettings.json 

### DIFF
--- a/src/Application/Common/Configurations/IdentitySettings.cs
+++ b/src/Application/Common/Configurations/IdentitySettings.cs
@@ -19,23 +19,28 @@ public class IdentitySettings
     public int RequiredLength { get; set; } = 6;
 
     /// <summary>
+    /// Gets or sets a value indicating what the maximum required length of a password should be.
+    /// </summary>
+    public int MaxLength { get; set; } = 16;
+    
+    /// <summary>
     /// Gets or sets a value indicating whether the password should require a non-alphanumeric(not: 0-9, A-Z) character.
     /// </summary>
-    public bool RequireNonAlphanumeric = true;
+    public bool RequireNonAlphanumeric { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether a password should require an upper-case character.
     /// </summary>
-    public bool RequireUpperCase = true;
+    public bool RequireUpperCase { get; set; } = true;
     
     /// <summary>
     /// Gets or sets a value indicating whether a password should require an lower-case character.
     /// </summary>
-    public bool RequireLowerCase = false;
+    public bool RequireLowerCase { get; set; } = false;
     
     // Lockout settings.
     /// <summary>
     /// Gets or sets a value indicating what the default lockout TimeSpan should be, measured in minutes.
     /// </summary>
-    public int DefaultLockoutTimeSpan = 30;
+    public int DefaultLockoutTimeSpan { get; set; } = 30;
 }

--- a/src/Application/Common/Configurations/IdentitySettings.cs
+++ b/src/Application/Common/Configurations/IdentitySettings.cs
@@ -1,0 +1,41 @@
+namespace CleanArchitecture.Blazor.Application.Common.Configurations;
+
+public class IdentitySettings
+{
+    /// <summary>
+    ///     Identity settings key constraint
+    /// </summary>
+    public const string Key = nameof(IdentitySettings);
+    
+    // Password settings.
+    /// <summary>
+    /// Gets or sets a value indicating whether a password should require a digit.
+    /// </summary>
+    public bool RequireDigit { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating what the minimum required length of a password should be.
+    /// </summary>
+    public int RequiredLength { get; set; } = 6;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the password should require a non-alphanumeric(not: 0-9, A-Z) character.
+    /// </summary>
+    public bool RequireNonAlphanumeric = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a password should require an upper-case character.
+    /// </summary>
+    public bool RequireUpperCase = true;
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether a password should require an lower-case character.
+    /// </summary>
+    public bool RequireLowerCase = false;
+    
+    // Lockout settings.
+    /// <summary>
+    /// Gets or sets a value indicating what the default lockout TimeSpan should be, measured in minutes.
+    /// </summary>
+    public int DefaultLockoutTimeSpan = 30;
+}

--- a/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
+++ b/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
@@ -24,13 +24,13 @@ public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormMo
             .NotEmpty()
             .MaximumLength(255)
             .EmailAddress();
-        RuleFor(p => p.Password).NotEmpty().WithMessage(_localizer["Your password cannot be empty"])
-                  .MinimumLength(identitySettings.RequiredLength).WithMessage(_localizer["Your password length must be at least 6."])
-                  .MaximumLength(identitySettings.MaxLength).WithMessage(_localizer["Your password length must not exceed 16."])
-                  .Matches(identitySettings.RequireUpperCase ? @"[A-Z]+" : string.Empty).WithMessage(_localizer["Your password must contain at least one uppercase letter."])
-                  .Matches(identitySettings.RequireLowerCase ? @"[a-z]+" : string.Empty).WithMessage(_localizer["Your password must contain at least one lowercase letter."])
-                  .Matches(identitySettings.RequireDigit ? @"[0-9]+" : string.Empty).WithMessage(_localizer["Your password must contain at least one number."])
-                  .Matches(identitySettings.RequireNonAlphanumeric ? @"[\@\!\?\*\.]+" : string.Empty).WithMessage(_localizer["Your password must contain at least one (@!? *.)."]);
+        RuleFor(p => p.Password).NotEmpty().WithMessage(_localizer["CannotBeEmpty"])
+                  .MinimumLength(identitySettings.RequiredLength).WithMessage(string.Format(_localizer["MinLength"], identitySettings.RequiredLength))
+                  .MaximumLength(identitySettings.MaxLength).WithMessage(_localizer["MaxLength"])
+                  .Matches(identitySettings.RequireUpperCase ? @"[A-Z]+" : string.Empty).WithMessage(_localizer["MustContainUpperCase"])
+                  .Matches(identitySettings.RequireLowerCase ? @"[a-z]+" : string.Empty).WithMessage(_localizer["MustContainLowerCase"])
+                  .Matches(identitySettings.RequireDigit ? @"[0-9]+" : string.Empty).WithMessage(_localizer["MustContainDigit"])
+                  .Matches(identitySettings.RequireNonAlphanumeric ? @"[\@\!\?\*\.]+" : string.Empty).WithMessage(_localizer["MustContainAlphanumericCharacter"]);
         RuleFor(x => x.ConfirmPassword)
              .Equal(x => x.Password);
         RuleFor(x => x.AgreeToTerms)

--- a/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
+++ b/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
@@ -1,4 +1,5 @@
 using CleanArchitecture.Blazor.Application.Common.Configurations;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 
 namespace CleanArchitecture.Blazor.Application.Common.Security;
@@ -6,7 +7,6 @@ namespace CleanArchitecture.Blazor.Application.Common.Security;
 public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormModel>
 {
     private readonly IStringLocalizer<RegisterFormModelFluentValidator> _localizer;
-    private readonly IConfiguration _configuration;
 
     public RegisterFormModelFluentValidator(
         IStringLocalizer<RegisterFormModelFluentValidator> localizer,
@@ -14,10 +14,8 @@ public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormMo
         )
     {
         _localizer = localizer;
-        _configuration = configuration;
-        
-        var identitySettings = new IdentitySettings();
-        configuration.GetSection(nameof(IdentitySettings)).Bind(identitySettings);
+
+        var identitySettings = configuration.GetRequiredSection(IdentitySettings.Key).Get<IdentitySettings>();
         RuleFor(x => x.UserName)
             .NotEmpty()
             .Length(2, 100);

--- a/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
+++ b/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
@@ -15,6 +15,7 @@ public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormMo
     {
         _localizer = localizer;
         _configuration = configuration;
+        
         var identitySettings = new IdentitySettings();
         configuration.GetSection(nameof(IdentitySettings)).Bind(identitySettings);
         RuleFor(x => x.UserName)
@@ -26,7 +27,7 @@ public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormMo
             .EmailAddress();
         RuleFor(p => p.Password).NotEmpty().WithMessage(_localizer["CannotBeEmpty"])
                   .MinimumLength(identitySettings.RequiredLength).WithMessage(string.Format(_localizer["MinLength"], identitySettings.RequiredLength))
-                  .MaximumLength(identitySettings.MaxLength).WithMessage(_localizer["MaxLength"])
+                  .MaximumLength(identitySettings.MaxLength).WithMessage(string.Format(_localizer["MaxLength"], identitySettings.MaxLength))
                   .Matches(identitySettings.RequireUpperCase ? @"[A-Z]+" : string.Empty).WithMessage(_localizer["MustContainUpperCase"])
                   .Matches(identitySettings.RequireLowerCase ? @"[a-z]+" : string.Empty).WithMessage(_localizer["MustContainLowerCase"])
                   .Matches(identitySettings.RequireDigit ? @"[0-9]+" : string.Empty).WithMessage(_localizer["MustContainDigit"])

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.ca-ES.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.ca-ES.resx
@@ -117,25 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>La teva contrasenya no pot estar buida</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>La vostra contrasenya no pot estar buida</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>La longitud de la seva contrasenya ha de ser d'almenys 6.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>La vostra contrasenya no ha de superar els {0} caràcters.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>La longitud de la seva contrasenya no pot ser superior a 16.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>La vostra contrasenya ha de tenir com a mínim {0} caràcters</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>La seva contrasenya ha de tenir almenys una (@!? *.).</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>La vostra contrasenya ha de contenir un caràcter alfanumèric</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>La seva contrasenya ha de tenir almenys una lletra minúscula.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>La vostra contrasenya ha de contenir un dígit</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>La seva contrasenya ha de tenir almenys un número.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>La vostra contrasenya ha de contenir almenys una lletra majúscula.</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>La seva contrasenya ha de tenir almenys una lletra majúscula.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>La vostra contrasenya ha de contenir almenys una lletra minúscula.</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.de-DE.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.de-DE.resx
@@ -117,25 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>Ihr Passwort darf nicht leer sein</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>Ihr Passwort darf nicht leer sein</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>Die Länge Ihres Passworts muss mindestens 6 betragen.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Ihr Passwort darf nicht länger als {0} Zeichen sein.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>Die Länge Ihres Passworts darf 16 nicht überschreiten.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>Ihr Passwort muss mindestens {0} Zeichen lang sein</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>Ihr Passwort muss mindestens ein (@!? *.) enthalten.</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>Ihr Passwort muss ein alphanumerisches Zeichen enthalten</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>Ihr Passwort muss mindestens einen Kleinbuchstaben enthalten.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>Ihr Passwort muss eine Ziffer enthalten</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>Ihr Passwort muss mindestens eine Zahl enthalten.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>Ihr Passwort muss mindestens einen Großbuchstaben enthalten.</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>Ihr Passwort muss mindestens einen Großbuchstaben enthalten.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>Ihr Passwort muss mindestens einen Kleinbuchstaben enthalten.</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.en.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.en.resx
@@ -117,25 +117,27 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>Your password cannot be empty</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>Your password cannot be empty</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>Your password length must be at least 6.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Your password must not exceed {0} characters.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>Your password length must not exceed 16.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>Your password must be at least {0} characters long</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>Your password must contain at least one (@!? *.).</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>Your password must contain an alphanumeric character</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>Your password must contain at least one lowercase letter.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>Your password must contain a digit.</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>Your password must contain at least one number.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>
+Your password must contain at least one uppercase letter.
+</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>Your password must contain at least one uppercase letter.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>Your password must contain at least one lowercase letter.</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.es-ES.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.es-ES.resx
@@ -117,25 +117,26 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>Su contraseña no puede estar vacía</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>Tu contraseña no puede estar vacía</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>La longitud de su contraseña debe ser de al menos 6.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Su contraseña no debe exceder los {0} caracteres.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>La longitud de su contraseña no debe ser superior a 16.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>
+Su contraseña debe tener al menos {0} caracteres</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>Su contraseña debe contener al menos una (@!? *.).</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>Su contraseña debe contener un carácter alfanumérico</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>Su contraseña debe contener al menos una letra minúscula.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>Su contraseña debe contener un dígito.</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>Su contraseña debe contener al menos un número.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>Su contraseña debe contener al menos una letra mayúscula.</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>Su contraseña debe contener al menos una letra mayúscula.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>Su contraseña debe contener al menos una letra minúscula.</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.fr-FR.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.fr-FR.resx
@@ -117,25 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>Votre mot de passe ne peut pas être vide</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>Votre mot de passe ne peut pas être vide</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>La longueur de votre mot de passe doit être d'au moins 6.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Votre mot de passe ne doit pas dépasser {0} caractères.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>La longueur de votre mot de passe ne doit pas dépasser 16.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>Votre mot de passe doit comporter au moins {0} caractères</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>Votre mot de passe doit contenir au moins un (@ !? *.).</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>Votre mot de passe doit contenir un caractère alphanumérique</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>Votre mot de passe doit contenir au moins une lettre minuscule.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>Votre mot de passe doit contenir un chiffre.</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>Votre mot de passe doit contenir au moins un chiffre.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>Votre mot de passe doit contenir au moins une lettre majuscule.</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>Votre mot de passe doit contenir au moins une lettre majuscule.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>Votre mot de passe doit contenir au moins une lettre minuscule.</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.ja-JP.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.ja-JP.resx
@@ -117,25 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>パスワードは空白にできません。</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>パスワードを空にすることはできません</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>パスワードの長さは6以上でなければなりません。</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Your password must not exceed {0} characters.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>パスワードの長さが16を超えないようにしてください。</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>パスワードは6文字以上である必要があります</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>パスワードには、少なくとも1つの(@!?*.)が含まれていなければなりません。</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>パスワードには英数字が含まれている必要があります</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>パスワードには、少なくとも1つの小文字が含まれていなければなりません。</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>パスワードには数字が含まれている必要があります。</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>パスワードには、少なくとも1つの数字が含まれていなければなりません。</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>パスワードには少なくとも 1 つの大文字が含まれている必要があります。</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>パスワードには、少なくとも1つの大文字が含まれていなければなりません。</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>パスワードには少なくとも 1 つの小文字が含まれている必要があります。</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.km-KH.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.km-KH.resx
@@ -117,25 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>비밀번호는 비워둘 수 없습니다.</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកមិនអាចទទេបានទេ។</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>비밀번호 길이는 6 이상이어야 합니다.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកមិនត្រូវលើសពី {0} តួអក្សរទេ។</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>비밀번호 길이는 16을 초과할 수 없습니다.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកត្រូវតែមានយ៉ាងហោចណាស់ {0} តួអក្សរ</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>비밀번호에는 최소 하나(@!? *.)가 포함되어야 합니다.</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកត្រូវតែមានតួអក្សរអក្សរក្រមលេខ</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>비밀번호에는 소문자가 하나 이상 포함되어야 합니다.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកត្រូវតែមានលេខ។</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>비밀번호에는 하나 이상의 숫자가 포함되어야 합니다.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកត្រូវតែមានយ៉ាងហោចណាស់អក្សរធំមួយ។</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>비밀번호는 적어도 하나의 대문자를 포함해야 합니다.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>ពាក្យសម្ងាត់របស់អ្នកត្រូវតែមានយ៉ាងហោចណាស់អក្សរតូចមួយ។</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.resx
@@ -117,25 +117,27 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>Your password cannot be empty</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>Your password cannot be empty</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>Your password length must be at least 6.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>Your password must be at least {0} characters long</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>Your password length must not exceed 16.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Your password must not exceed {0} characters.</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>Your password must contain at least one (@!? *.).</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+    <value>MustContainAlphanumericCharacter</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>Your password must contain at least one lowercase letter.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>Your password must contain at least one lowercase letter.</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>Your password must contain at least one number.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>Your password must contain a digit.</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>Your password must contain at least one uppercase letter.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>
+Your password must contain at least one uppercase letter.
+</value>
   </data>
 </root>

--- a/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.ru.resx
+++ b/src/Application/Resources/Common/Security/RegisterFormModelFluentValidator.ru.resx
@@ -117,25 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Your password cannot be empty" xml:space="preserve">
-    <value>Ваш пароль не может быть пустым</value>
+  <data name="CannotBeEmpty" xml:space="preserve">
+      <value>Ваш пароль не может быть пустым</value>
   </data>
-  <data name="Your password length must be at least 6." xml:space="preserve">
-    <value>Длина вашего пароля должна быть не менее 6.</value>
+  <data name="MaxLength" xml:space="preserve">
+      <value>Ваш пароль не должен превышать {0} символов.</value>
   </data>
-  <data name="Your password length must not exceed 16." xml:space="preserve">
-    <value>Длина вашего пароля не должна превышать 16.</value>
+  <data name="MinLength" xml:space="preserve">
+      <value>Ваш пароль должен содержать не менее {0} символов.</value>
   </data>
-  <data name="Your password must contain at least one (@!? *.)." xml:space="preserve">
-    <value>Ваш пароль должен содержать хотя бы один символ (@!? *.).</value>
+  <data name="MustContainAlphanumericCharacter" xml:space="preserve">
+      <value>Ваш пароль должен содержать буквенно-цифровой символ</value>
   </data>
-  <data name="Your password must contain at least one lowercase letter." xml:space="preserve">
-    <value>Ваш пароль должен содержать хотя бы одну строчную букву.</value>
+  <data name="MustContainDigit" xml:space="preserve">
+      <value>Ваш пароль должен содержать цифру.</value>
   </data>
-  <data name="Your password must contain at least one number." xml:space="preserve">
-    <value>Ваш пароль должен содержать хотя бы одну цифру.</value>
+  <data name="MustContainUpperCase" xml:space="preserve">
+      <value>Ваш пароль должен содержать хотя бы одну заглавную букву.</value>
   </data>
-  <data name="Your password must contain at least one uppercase letter." xml:space="preserve">
-    <value>Ваш пароль должен содержать хотя бы одну заглавную букву.</value>
+  <data name="MustContainLowerCase" xml:space="preserve">
+      <value>Ваш пароль должен содержать хотя бы одну строчную букву.</value>
   </data>
 </root>

--- a/src/Blazor.Server.UI/appsettings.json
+++ b/src/Blazor.Server.UI/appsettings.json
@@ -73,5 +73,14 @@
     "Properties": {
       "Application": "BlazorApp"
     }
+  },
+  "IdentitySettings": {
+    "RequireDigit": false,
+    "RequiredLength": 2,
+    "MaxLength":16,
+    "RequireNonAlphanumeric": false,
+    "RequireUpperCase": false,
+    "RequireLowerCase": false,
+    "DefaultLockoutTimeSpan": 30
   }
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -20,9 +20,11 @@ public static class DependencyInjection
         services.Configure<DashboardSettings>(configuration.GetSection(DashboardSettings.Key));
         services.Configure<DatabaseSettings>(configuration.GetSection(DatabaseSettings.Key));
         services.Configure<AppConfigurationSettings>(configuration.GetSection(AppConfigurationSettings.Key));
+        services.Configure<IdentitySettings>(configuration.GetSection(IdentitySettings.Key));
         services.AddSingleton(s => s.GetRequiredService<IOptions<DashboardSettings>>().Value);
         services.AddSingleton(s => s.GetRequiredService<IOptions<DatabaseSettings>>().Value);
         services.AddSingleton(s => s.GetRequiredService<IOptions<AppConfigurationSettings>>().Value);
+        services.AddSingleton(s => s.GetRequiredService<IOptions<IdentitySettings>>().Value);
         services.AddScoped<AuthenticationStateProvider, BlazorAuthStateProvider>();
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         services.AddScoped<ITenantProvider, TenantProvider>();

--- a/src/Infrastructure/Extensions/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/AuthenticationServiceCollectionExtensions.cs
@@ -21,8 +21,7 @@ public static class AuthenticationServiceCollectionExtensions
             .AddDefaultTokenProviders();
         services.Configure<IdentityOptions>(options =>
         {
-            var identitySettings = new IdentitySettings();
-            configuration.GetSection(nameof(IdentitySettings)).Bind(identitySettings);
+            var identitySettings = configuration.GetRequiredSection(IdentitySettings.Key).Get<IdentitySettings>();
             // Password settings
             options.Password.RequireDigit = identitySettings.RequireDigit;
             options.Password.RequiredLength = identitySettings.RequiredLength;

--- a/src/Infrastructure/Extensions/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Extensions/AuthenticationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text;
+using CleanArchitecture.Blazor.Application.Common.Configurations;
 using CleanArchitecture.Blazor.Application.Constants.ClaimTypes;
 using CleanArchitecture.Blazor.Application.Constants.Permission;
 using CleanArchitecture.Blazor.Application.Constants.User;
@@ -20,15 +21,17 @@ public static class AuthenticationServiceCollectionExtensions
             .AddDefaultTokenProviders();
         services.Configure<IdentityOptions>(options =>
         {
+            var identitySettings = new IdentitySettings();
+            configuration.GetSection(nameof(IdentitySettings)).Bind(identitySettings);
             // Password settings
-            options.Password.RequireDigit = true;
-            options.Password.RequiredLength = 6;
-            options.Password.RequireNonAlphanumeric = true;
-            options.Password.RequireUppercase = true;
-            options.Password.RequireLowercase = false;
+            options.Password.RequireDigit = identitySettings.RequireDigit;
+            options.Password.RequiredLength = identitySettings.RequiredLength;
+            options.Password.RequireNonAlphanumeric = identitySettings.RequireNonAlphanumeric;
+            options.Password.RequireUppercase = identitySettings.RequireUpperCase;
+            options.Password.RequireLowercase = identitySettings.RequireLowerCase;
 
             // Lockout settings
-            options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(30);
+            options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(identitySettings.DefaultLockoutTimeSpan);
             options.Lockout.MaxFailedAccessAttempts = 10;
             options.Lockout.AllowedForNewUsers = true;
 


### PR DESCRIPTION
- Added identity password settings to appsettings.json
- Made the password validations and the messages in RegisterFormModelFluentValidator.cs synced with the settings instead of being hardcoded (before this was fine as it was not configurable anyway)
- Changed the names of the validation translations to short variable-like names instead of the entire English value which should make it look more clean.
