### PR TITLE
Enhance PerformanceBehaviour with request count and detailed docs

### DIFF
--- a/src/Application/Common/Behaviours/PerformanceBehaviour.cs
+++ b/src/Application/Common/Behaviours/PerformanceBehaviour.cs
@@ -1,44 +1,68 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Diagnostics;
 
 namespace CleanArchitecture.Blazor.Application.Common.Behaviours;
 
-public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+/// <summary>
+///     This class is a behavior pipeline in MediatR. It is used to monitor performance
+///     and log warnings if a request takes longer to execute than a specified threshold.
+/// </summary>
+/// <typeparam name="TRequest">Type of the Request</typeparam>
+/// <typeparam name="TResponse">Type of the Response</typeparam>
+public class PerformanceBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
 {
-    private readonly Stopwatch _timer;
-    private readonly ILogger<TRequest> _logger;
     private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<PerformanceBehaviour<TRequest, TResponse>> _logger;
 
     public PerformanceBehaviour(
-        ILogger<TRequest> logger,
-        ICurrentUserService currentUserService )
+        ILogger<PerformanceBehaviour<TRequest, TResponse>> logger,
+        ICurrentUserService currentUserService)
     {
-        _timer = new Stopwatch();
-
         _logger = logger;
         _currentUserService = currentUserService;
     }
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    /// <summary>
+    ///     Logs warnings if a request takes longer to execute than a specified threshold.
+    /// </summary>
+    /// <param name="request">The incoming request</param>
+    /// <param name="next">The delegate for the next action in the pipeline process.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response from the next delegate</returns>
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
     {
-        _timer.Start();
+        Stopwatch? timer = null;
 
-        var response = await next().ConfigureAwait(false); ;
+        // Increment ExecutionCount in a thread-safe manner.
+        Interlocked.Increment(ref RequestCounter.ExecutionCount);
+        if (RequestCounter.ExecutionCount > 3) timer = Stopwatch.StartNew();
 
-        _timer.Stop();
+        var response = await next().ConfigureAwait(false);
 
-        var elapsedMilliseconds = _timer.ElapsedMilliseconds;
+        timer?.Stop();
+        var elapsedMilliseconds = timer?.ElapsedMilliseconds;
 
         if (elapsedMilliseconds > 500)
         {
             var requestName = typeof(TRequest).Name;
-
             var userName = _currentUserService.UserName;
-            _logger.LogWarning("{Name} long running request ({ElapsedMilliseconds} milliseconds) with {@Request} {@UserName} ",
+
+            _logger.LogWarning(
+                "{Name} long running request ({ElapsedMilliseconds} milliseconds) with {@Request} {@UserName} ",
                 requestName, elapsedMilliseconds, request, userName);
         }
+
         return response;
     }
+}
+
+/// <summary>
+///     Static class that holds the ExecutionCount in a shared context between different
+///     instances of our PerformanceBehaviour class, regardless of the type of TRequest.
+///     This allows to keep track of the number of requests application-wide.
+/// </summary>
+public static class RequestCounter
+{
+    public static int ExecutionCount;
 }


### PR DESCRIPTION
PerformanceBehaviour of the MediatR pipeline has been improved to introduce a request counter to track the number of requests application-wide.

This counter increments thread-safely and initiates performance timing only after the first 3 requests to avoid skewing data due to just-in-time compilation or other startup overheads. Also introduced detailed class and method commenting to enhance code understandability.

#### Changed The ILogger Paramater
- **[Logger Type Parameter Update]** Updated the logger in `PerformanceBehaviour` to be more specific:
  - Before: `private readonly ILogger<TRequest> _logger;`
  - After: `private readonly ILogger<PerformanceBehaviour<TRequest, TResponse>> _logger;`
  - This change allows for more context-aware logging within the `PerformanceBehaviour` class.