### PR TITLE
Added ValidationService and sample use case

### DIFF
--- a/src/Application/Common/Helper/ValidationHelper.cs
+++ b/src/Application/Common/Helper/ValidationHelper.cs
@@ -1,0 +1,22 @@
+﻿namespace CleanArchitecture.Blazor.Application.Common.Helper;
+public static class ValidationHelper
+{
+    public static async Task<IDictionary<string, string[]>> ValidateAsync<TRequest>(IEnumerable<IValidator<TRequest>> validators, ValidationContext<TRequest> validationContext, CancellationToken cancellationToken = default)
+    {
+        if (validators.Any())
+        {
+            var validationResults = await Task.WhenAll(
+                validators.Select(v => v.ValidateAsync(validationContext, cancellationToken)));
+
+            var failures = validationResults
+                .SelectMany(r => r.Errors)
+                .Where(f => f != null)
+                .ToList();
+
+            return failures.GroupBy(e => e.PropertyName, e => e.ErrorMessage)
+                    .ToDictionary(g => g.Key, g => g.ToArray());
+        }
+
+        return new Dictionary<string, string[]>();
+    }
+}

--- a/src/Application/Common/Interfaces/IValidationService.cs
+++ b/src/Application/Common/Interfaces/IValidationService.cs
@@ -1,0 +1,15 @@
+﻿using FluentValidation.Internal;
+
+namespace CleanArchitecture.Blazor.Application.Common.Interfaces;
+public interface IValidationService
+{
+    Func<object, string, Task<IEnumerable<string>>> ValidateValue<TRequest>();
+    // NOTE: providing the model as parameter is not required,
+    // it's just easier to write and nicer to read in the blazor component
+    // instead of the explicit declaration of the model type
+    Func<object, string, Task<IEnumerable<string>>> ValidateValue<TRequest>(TRequest _);
+    Task<IDictionary<string, string[]>> ValidateAsync<TRequest>(TRequest model, CancellationToken cancellationToken = default);
+    Task<IDictionary<string, string[]>> ValidateAsync<TRequest>(TRequest model, Action<ValidationStrategy<TRequest>> options, CancellationToken cancellationToken = default);
+    Task<IEnumerable<string>> ValidatePropertyAsync<TRequest>(TRequest model, string propertyName, CancellationToken cancellationToken = default);
+
+}

--- a/src/Application/Common/Models/UserProfile.cs
+++ b/src/Application/Common/Models/UserProfile.cs
@@ -29,11 +29,4 @@ public class UserProfileEditValidator : AbstractValidator<UserProfile>
         RuleFor(x => x.PhoneNumber)
             .MaximumLength(128);
     }
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        var result = await ValidateAsync(ValidationContext<UserProfile>.CreateWithOptions((UserProfile)model, x => x.IncludeProperties(propertyName)));
-        if (result.IsValid)
-            return Array.Empty<string>();
-        return result.Errors.Select(e => e.ErrorMessage);
-    };
 }

--- a/src/Application/Common/Security/LoginFormModel.cs
+++ b/src/Application/Common/Security/LoginFormModel.cs
@@ -25,11 +25,5 @@ public class LoginFormModelFluentValidator : AbstractValidator<LoginFormModel>
             .MaximumLength(16).WithMessage(_localizer["Your password length must not exceed 16 characters."]);
     }
 
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        ValidationResult? result =
-            await ValidateAsync(ValidationContext<LoginFormModel>.CreateWithOptions((LoginFormModel)model,
-                x => x.IncludeProperties(propertyName)));
-        return result.IsValid ? Array.Empty<string>() : result.Errors.Select(e => e.ErrorMessage);
-    };
+   
 }

--- a/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
+++ b/src/Application/Common/Security/RegisterFormModelFluentValidator.cs
@@ -24,7 +24,7 @@ public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormMo
             .MaximumLength(255)
             .EmailAddress();
         RuleFor(p => p.Password).NotEmpty().WithMessage(_localizer["CannotBeEmpty"])
-                  .MinimumLength(identitySettings.RequiredLength).WithMessage(string.Format(_localizer["MinLength"], identitySettings.RequiredLength))
+                  .MinimumLength(identitySettings!.RequiredLength).WithMessage(string.Format(_localizer["MinLength"], identitySettings.RequiredLength))
                   .MaximumLength(identitySettings.MaxLength).WithMessage(string.Format(_localizer["MaxLength"], identitySettings.MaxLength))
                   .Matches(identitySettings.RequireUpperCase ? @"[A-Z]+" : string.Empty).WithMessage(_localizer["MustContainUpperCase"])
                   .Matches(identitySettings.RequireLowerCase ? @"[a-z]+" : string.Empty).WithMessage(_localizer["MustContainLowerCase"])
@@ -34,15 +34,7 @@ public class RegisterFormModelFluentValidator : AbstractValidator<RegisterFormMo
              .Equal(x => x.Password);
         RuleFor(x => x.AgreeToTerms)
             .Equal(true);
-        
-    }
 
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        var result = await ValidateAsync(ValidationContext<RegisterFormModel>.CreateWithOptions((RegisterFormModel)model, x => x.IncludeProperties(propertyName)));
-        if (result.IsValid)
-            return Array.Empty<string>();
-        return result.Errors.Select(e => e.ErrorMessage);
-    };
+    }
 }
 

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -7,6 +7,7 @@ using CleanArchitecture.Blazor.Application.Common.PublishStrategies;
 using CleanArchitecture.Blazor.Application.Common.Security;
 using CleanArchitecture.Blazor.Application.Services.MultiTenant;
 using CleanArchitecture.Blazor.Application.Services.Picklist;
+using CleanArchitecture.Blazor.Application.Services.Validation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CleanArchitecture.Blazor.Application;
@@ -27,8 +28,8 @@ public static class DependencyInjection
             config.AddOpenBehavior(typeof(MemoryCacheBehaviour<,>));
             config.AddOpenBehavior(typeof(AuthorizationBehaviour<,>));
             config.AddOpenBehavior(typeof(CacheInvalidationBehaviour<,>));
-         
-            
+
+
         });
         services.AddFluxor(options => {
             options.ScanAssemblies(Assembly.GetExecutingAssembly());
@@ -40,15 +41,15 @@ public static class DependencyInjection
             var service = sp.GetRequiredService<PicklistService>();
             service.Initialize();
             return service;
-            });
+        });
         services.AddSingleton<TenantService>();
         services.AddSingleton<ITenantService>(sp => {
             var service = sp.GetRequiredService<TenantService>();
             service.Initialize();
             return service;
         });
-        services.AddScoped<RegisterFormModelFluentValidator>();
+        services.AddScoped<IValidationService, ValidationService>();
         return services;
     }
-   
+
 }

--- a/src/Application/Features/Customers/Commands/AddEdit/AddEditCustomerCommandValidator.cs
+++ b/src/Application/Features/Customers/Commands/AddEdit/AddEditCustomerCommandValidator.cs
@@ -13,12 +13,6 @@ public class AddEditCustomerCommandValidator : AbstractValidator<AddEditCustomer
            //      .NotEmpty();
            throw new System.NotImplementedException();
      }
-     public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-     {
-        var result = await ValidateAsync(ValidationContext<AddEditCustomerCommand>.CreateWithOptions((AddEditCustomerCommand)model, x => x.IncludeProperties(propertyName)));
-        if (result.IsValid)
-            return Array.Empty<string>();
-        return result.Errors.Select(e => e.ErrorMessage);
-     };
+    
 }
 

--- a/src/Application/Features/Customers/Commands/Create/CreateCustomerCommandValidator.cs
+++ b/src/Application/Features/Customers/Commands/Create/CreateCustomerCommandValidator.cs
@@ -3,22 +3,16 @@
 
 namespace CleanArchitecture.Blazor.Application.Features.Customers.Commands.Create;
 
-    public class CreateCustomerCommandValidator : AbstractValidator<CreateCustomerCommand>
+public class CreateCustomerCommandValidator : AbstractValidator<CreateCustomerCommand>
+{
+    public CreateCustomerCommandValidator()
     {
-        public CreateCustomerCommandValidator()
-        {
-           // TODO: Implement CreateCustomerCommandValidator method, for example: 
-           // RuleFor(v => v.Name)
-           //      .MaximumLength(256)
-           //      .NotEmpty();
-           throw new System.NotImplementedException();
-        }
-        public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-     {
-        var result = await ValidateAsync(ValidationContext<CreateCustomerCommand>.CreateWithOptions((CreateCustomerCommand)model, x => x.IncludeProperties(propertyName)));
-        if (result.IsValid)
-            return Array.Empty<string>();
-        return result.Errors.Select(e => e.ErrorMessage);
-     };
+        // TODO: Implement CreateCustomerCommandValidator method, for example: 
+        // RuleFor(v => v.Name)
+        //      .MaximumLength(256)
+        //      .NotEmpty();
+        throw new System.NotImplementedException();
     }
+   
+}
 

--- a/src/Application/Features/Customers/Commands/Update/UpdateCustomerCommandValidator.cs
+++ b/src/Application/Features/Customers/Commands/Update/UpdateCustomerCommandValidator.cs
@@ -13,12 +13,6 @@ public class UpdateCustomerCommandValidator : AbstractValidator<UpdateCustomerCo
            //      .NotEmpty();
            throw new System.NotImplementedException();
         }
-     public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-     {
-        var result = await ValidateAsync(ValidationContext<UpdateCustomerCommand>.CreateWithOptions((UpdateCustomerCommand)model, x => x.IncludeProperties(propertyName)));
-        if (result.IsValid)
-            return Array.Empty<string>();
-        return result.Errors.Select(e => e.ErrorMessage);
-     };
+    
 }
 

--- a/src/Application/Features/Documents/Commands/AddEdit/AddEditDocumentCommandValidator.cs
+++ b/src/Application/Features/Documents/Commands/AddEdit/AddEditDocumentCommandValidator.cs
@@ -20,12 +20,5 @@ public class AddEditDocumentCommandValidator : AbstractValidator<AddEditDocument
             .When(x => x.Id <= 0);
     }
 
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        var result =
-            await ValidateAsync(
-                ValidationContext<AddEditDocumentCommand>.CreateWithOptions((AddEditDocumentCommand)model,
-                    x => x.IncludeProperties(propertyName)));
-        return result.IsValid ? Array.Empty<string>() : result.Errors.Select(e => e.ErrorMessage);
-    };
+    
 }

--- a/src/Application/Features/KeyValues/Commands/AddEdit/AddEditKeyValueCommandValidator.cs
+++ b/src/Application/Features/KeyValues/Commands/AddEdit/AddEditKeyValueCommandValidator.cs
@@ -12,12 +12,5 @@ public class AddEditKeyValueCommandValidator : AbstractValidator<AddEditKeyValue
         RuleFor(v => v.Value).MaximumLength(256).NotEmpty();
     }
 
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        var result =
-            await ValidateAsync(
-                ValidationContext<AddEditKeyValueCommand>.CreateWithOptions((AddEditKeyValueCommand)model,
-                    x => x.IncludeProperties(propertyName)));
-        return result.IsValid ? Array.Empty<string>() : result.Errors.Select(e => e.ErrorMessage);
-    };
+    
 }

--- a/src/Application/Features/Products/Commands/AddEdit/AddEditProductCommandValidator.cs
+++ b/src/Application/Features/Products/Commands/AddEdit/AddEditProductCommandValidator.cs
@@ -24,12 +24,4 @@ public class AddEditProductCommandValidator : AbstractValidator<AddEditProductCo
         RuleFor(v => v.UploadPictures).NotEmpty().When(x => x.Pictures == null || !x.Pictures.Any())
             .WithMessage("Please upload product pictures.");
     }
-
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        var result =
-            await ValidateAsync(ValidationContext<AddEditProductCommand>.CreateWithOptions((AddEditProductCommand)model,
-                x => x.IncludeProperties(propertyName)));
-        return result.IsValid ? Array.Empty<string>() : result.Errors.Select(e => e.ErrorMessage);
-    };
 }

--- a/src/Application/Features/Tenants/Commands/AddEdit/AddEditTenantCommandValidator.cs
+++ b/src/Application/Features/Tenants/Commands/AddEdit/AddEditTenantCommandValidator.cs
@@ -12,11 +12,5 @@ public class AddEditTenantCommandValidator : AbstractValidator<AddEditTenantComm
             .NotEmpty();
     }
 
-    public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>
-    {
-        var result =
-            await ValidateAsync(ValidationContext<AddEditTenantCommand>.CreateWithOptions((AddEditTenantCommand)model,
-                x => x.IncludeProperties(propertyName)));
-        return result.IsValid ? Array.Empty<string>() : result.Errors.Select(e => e.ErrorMessage);
-    };
+    
 }

--- a/src/Application/Services/Validation/ValidationService.cs
+++ b/src/Application/Services/Validation/ValidationService.cs
@@ -1,0 +1,61 @@
+﻿using CleanArchitecture.Blazor.Application.Common.Helper;
+using FluentValidation.Internal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanArchitecture.Blazor.Application.Services.Validation;
+public class ValidationService : IValidationService
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    // in order to keep the service as generic as possible 
+    // validators are provided by type only when required,
+    // an alternative would be creating a IValidationService<TRequest>
+    // similar to the ValidationBehaviour<TRequest, TResponse>
+    // but that would mean injecting a IValidationService for each
+    // type of model to validate in a page
+    public ValidationService(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public Func<object, string, Task<IEnumerable<string>>> ValidateValue<TRequest>()
+        => async (model, propertyName)
+        => await ValidatePropertyAsync((TRequest)model, propertyName);
+
+    public Func<object, string, Task<IEnumerable<string>>> ValidateValue<TRequest>(TRequest _)
+        => this.ValidateValue<TRequest>();
+
+    public async Task<IDictionary<string, string[]>> ValidateAsync<TRequest>(TRequest model, CancellationToken cancellationToken = default)
+    {
+        var validators = _serviceProvider.GetServices<IValidator<TRequest>>();
+
+        var context = new ValidationContext<TRequest>(model);
+
+        return validators != null
+            ? await ValidationHelper.ValidateAsync(validators, context, cancellationToken)
+            : new Dictionary<string, string[]>();
+    }
+
+    public async Task<IDictionary<string, string[]>> ValidateAsync<TRequest>(TRequest model, Action<ValidationStrategy<TRequest>> options, CancellationToken cancellationToken = default)
+    {
+        var validators = _serviceProvider.GetServices<IValidator<TRequest>>();
+
+        var context = ValidationContext<TRequest>
+            .CreateWithOptions(model, options);
+
+        return validators != null
+            ? await ValidationHelper.ValidateAsync(validators, context, cancellationToken)
+            : new Dictionary<string, string[]>();
+    }
+
+    public async Task<IEnumerable<string>> ValidatePropertyAsync<TRequest>(TRequest model, string propertyName, CancellationToken cancellationToken = default)
+    {
+        var validationResult = await ValidateAsync(model,
+            options =>
+            {
+                options.IncludeProperties(propertyName);
+            }, cancellationToken);
+
+        return validationResult.Where(x => x.Key == propertyName).SelectMany(x => x.Value);
+    }
+}

--- a/src/Blazor.Server.UI/Pages/Authentication/Login.razor
+++ b/src/Blazor.Server.UI/Pages/Authentication/Login.razor
@@ -13,12 +13,13 @@
 @using Blazor.Server.UI.Pages.Identity.Users
 @using CleanArchitecture.Blazor.Application.Common.ExceptionHandlers
 @implements IDisposable
+@inject IValidationService Validator
 @inject IStringLocalizer<Login> L
 
 <PageTitle>@_title</PageTitle>
 <AuthorizeView>
     <NotAuthorized Context="auth">
-        <MudForm Model="@_model" @ref="@_form" @bind-IsValid="@_success" ValidationDelay="0" Validation="@(LoginValidator.ValidateValue)">
+        <MudForm Model="@_model" @ref="@_form" @bind-IsValid="@_success" ValidationDelay="0" Validation="@(Validator.ValidateValue(_model))">
             <MudText Typo="Typo.h4" GutterBottom="true">@L["Sign In"]</MudText>
             <MudText>
                 @L["Don't have an account?"] <MudLink Href="/pages/authentication/register">@L["Sign Up"]</MudLink>

--- a/src/Blazor.Server.UI/Pages/Authentication/Register.razor
+++ b/src/Blazor.Server.UI/Pages/Authentication/Register.razor
@@ -1,5 +1,6 @@
 @page "/pages/authentication/register"
 @inject IStringLocalizer<Register> L
+@inject IValidationService Validator
 @attribute [AllowAnonymous]
 @using CleanArchitecture.Blazor.Application.Common.Security
 @using CleanArchitecture.Blazor.Application.Constants.Role
@@ -8,7 +9,7 @@
 <PageTitle>@Title</PageTitle>
 <AuthorizeView>
     <NotAuthorized Context="Auth">
-        <MudForm Model="@_model" @ref="@_form" Validation="@(RegisterValidator.ValidateValue)">
+            <MudForm Model="@_model" @ref="@_form" Validation="@(Validator.ValidateValue(_model))">
             <MudText Typo="Typo.h4" GutterBottom="true">@L["Sign Up"]</MudText>
             <MudText>@L["have an account?"] <MudLink Href="/pages/authentication/login">@L["Sign In"]</MudLink></MudText>
 
@@ -84,7 +85,6 @@
     MudForm? _form;
     bool _loading;
     readonly RegisterFormModel _model = new();
-    [Inject] private RegisterFormModelFluentValidator RegisterValidator { get; set; } = default!;
     [Inject]
     private IMailService MailService { get; set; } = null!;
 

--- a/src/Blazor.Server.UI/Pages/Customers/_CustomerFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Customers/_CustomerFormDialog.razor
@@ -1,11 +1,12 @@
 ﻿@using CleanArchitecture.Blazor.Application.Features.Customers.Commands.AddEdit
 
 @inherits MudComponentBase
+@inject IValidationService Validator
 @inject IStringLocalizer<Customers> L
 
 <MudDialog>
     <DialogContent>
-        <MudForm Model="@model" @ref="@_form" Validation="@(_modelValidator.ValidateValue)">
+        <MudForm Model="@model" @ref="@_form" Validation="@(Validator.ValidateValue(model))">
             <MudGrid>
                 @*TODO: define mudform that should be edit fields, for example:*@
                 <MudItem xs="12" md="6"> 

--- a/src/Blazor.Server.UI/Pages/Documents/_DocumentFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Documents/_DocumentFormDialog.razor
@@ -1,10 +1,11 @@
 @using CleanArchitecture.Blazor.Application.Features.Documents.Commands.AddEdit
 @using CleanArchitecture.Blazor.Domain.Enums
 @inherits MudComponentBase
+@inject IValidationService Validator
 @inject IStringLocalizer<Documents> L
 <MudDialog>
     <DialogContent>
-        <MudForm Model="Model" @ref="_form" Validation="@(_modelValidator.ValidateValue)">
+        <MudForm Model="Model" @ref="_form" Validation="@(Validator.ValidateValue(Model))">
             <MudGrid>
                 <MudItem xs="12" sm="6">
                     <MudTextField Label="@L["Title"]" @bind-Value="Model.Title"

--- a/src/Blazor.Server.UI/Pages/Identity/Users/Profile.razor
+++ b/src/Blazor.Server.UI/Pages/Identity/Users/Profile.razor
@@ -6,6 +6,7 @@
 @using SixLabors.ImageSharp.Processing
 
 @inherits OwningComponentBase
+@inject IValidationService Validator
 @inject IStringLocalizer<Profile> L
 @inject IJSRuntime JS
 <PageTitle>@Title</PageTitle>
@@ -20,7 +21,7 @@
             <MudTabs Outlined="true" Position="Position.Top" Rounded="true" Border="true" Elevation="6" ActivePanelIndexChanged="ActivePanelIndexChanged"
                      ApplyEffectsToContainer="true" Class="mt-8" PanelClass="pa-6">
                 <MudTabPanel Text="@L["Profile"]">
-                    <MudForm Model="@model" @ref="@_form" Validation="@(_userValidator.ValidateValue)" Style="display: flex; align-content: center;  align-items: center; flex-direction: column;">
+                    <MudForm Model="@model" @ref="@_form" Validation="@(Validator.ValidateValue(model))" Style="display: flex; align-content: center;  align-items: center; flex-direction: column;">
                         <MudGrid Justify="Justify.Center" Style="max-width:600px;display:flex;">
                             <MudItem sm="12" xs="12">
                                 <div class="d-flex justify-center">

--- a/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Products/_ProductFormDialog.razor
@@ -6,9 +6,11 @@
 @inherits MudComponentBase
 @inject IJSRuntime JS
 @inject IStringLocalizer<Products> L
+@inject IValidationService Validator
+
 <MudDialog>
     <DialogContent>
-        <MudForm Model="@Model" @ref="@_form" Validation="@(_modelValidator.ValidateValue)">
+        <MudForm Model="@Model" @ref="@_form" Validation="@(Validator.ValidateValue(Model))">
             <MudGrid>
                 <MudItem xs="12">
                     <MudTextField Label="@L["Product Name"]" @bind-Value="Model.Name"
@@ -116,8 +118,6 @@
 
     [Inject]
     private IMediator Mediator { get; set; } = default!;
-
-    readonly AddEditProductCommandValidator _modelValidator = new();
 
     [EditorRequired]
     [Parameter]

--- a/src/Blazor.Server.UI/Pages/SystemManagement/_CreatePicklistDialog.razor
+++ b/src/Blazor.Server.UI/Pages/SystemManagement/_CreatePicklistDialog.razor
@@ -1,9 +1,10 @@
 @using CleanArchitecture.Blazor.Application.Features.KeyValues.Commands.AddEdit
 @inherits MudComponentBase
+@inject IValidationService Validator
 @inject IStringLocalizer<Dictionaries> L
 <MudDialog>
     <DialogContent>
-        <MudForm Model="model" @ref="_form" Validation="@(modelValidator.ValidateValue)">
+        <MudForm Model="model" @ref="_form" Validation="@(Validator.ValidateValue(model))">
             <MudGrid>
                 <MudItem xs="12" md="6">
                     <MudEnumSelect Label="@L[model.GetMemberDescription(x=>x.Name)]" @bind-Value="model.Name"

--- a/src/Blazor.Server.UI/Pages/Tenants/_TenantFormDialog.razor
+++ b/src/Blazor.Server.UI/Pages/Tenants/_TenantFormDialog.razor
@@ -1,9 +1,10 @@
 @using CleanArchitecture.Blazor.Application.Features.Tenants.Commands.AddEdit
 @inherits MudComponentBase
+@inject IValidationService Validator
 @inject IStringLocalizer<Tenants> L
 <MudDialog>
     <DialogContent>
-        <MudForm Model="Model" @ref="_form" Validation="@(_modelValidator.ValidateValue)">
+        <MudForm Model="Model" @ref="_form" Validation="@(Validator.ValidateValue(Model))">
             <MudGrid>
                 <MudItem xs="12">
                     <MudTextField Label="@L[Model.GetMemberDescription(x=>x.Id)]" @bind-Value="Model.Id"


### PR DESCRIPTION
Instead of writing the ValidateValue method in every Validator model and instantiating a validator class in blazor components I created a ValidationService that takes care of it.

I implemented it only for AddEditProductCommand and RegisterFormModel for demonstration purposes, if this is accepted all the validators could be updated.

In the case of RegisterFormModelFluentValidator injecting it as a services is no longer required since the ValidationService handles the service injection too.