### PR TITLE
Fixed: Using error in the UserLoginState component

### DIFF
--- a/src/Server.UI/Components/Identity/UserLoginState.razor
+++ b/src/Server.UI/Components/Identity/UserLoginState.razor
@@ -1,4 +1,4 @@
-﻿﻿@using CleanArchitecture.Blazor.Application.Common.Interfaces.Identity
+﻿@using CleanArchitecture.Blazor.Application.Common.Interfaces.Identity
 @using CleanArchitecture.Blazor.Server.UI.Hubs
 @using CleanArchitecture.Blazor.Server.UI.Models
 @using Microsoft.AspNetCore.Components.Authorization


### PR DESCRIPTION
I'm experiencing an import error when cloning this project in Rider, and I'm unsure why Git isn't detecting it. In my IDE it looks like this, and this PR should fix this issue.

![image](https://github.com/neozhu/CleanArchitectureWithBlazorServer/assets/70259613/0ab536f9-c010-49b5-a75a-31dff55c6946)
