### PR TITLE
Update copyright year in the configuration

### DIFF
--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -34,7 +34,7 @@
     "AppFlavor": "Blazor .NET 8.0",
     "AppFlavorSubscript": ".NET 8.0",
     "Company": "Company",
-    "Copyright": "@2023 Copyright"
+    "Copyright": "@2024 Copyright"
   },
   "AllowedHosts": "*",
   "SmtpClientOptions": {


### PR DESCRIPTION
The copyright year in the appsettings.json file was updated to reflect the current year 2024 instead of the previously used 2023.