### PR TITLE
Remove Deprecated AutoMapper.Extensions.Microsoft.DependencyInjection Library

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -14,8 +14,7 @@
         <PackageReference Include="jcamp.FluentEmail.Core" Version="3.7.0" />
         <PackageReference Include="jcamp.FluentEmail.MailKit" Version="3.7.0" />
         <PackageReference Include="jcamp.FluentEmail.Razor" Version="3.7.0" />
-        <PackageReference Include="AutoMapper" Version="12.0.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+        <PackageReference Include="AutoMapper" Version="13.0.1" />
         <PackageReference Include="FluentValidation" Version="11.9.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
         <PackageReference Include="LazyCache" Version="2.4.0" />


### PR DESCRIPTION
**Description:**

This pull request addresses the deprecation of the `AutoMapper.Extensions.Microsoft.DependencyInjection` library, which is no longer being maintained. The functionality provided by this library has been integrated into the main AutoMapper library.

**Changes Made:**

- Removed the deprecated `AutoMapper.Extensions.Microsoft.DependencyInjection` library from the project dependencies.
- Updated the AutoMapper library to utilize the functionality directly from the main library.
- Resolved the potential `Ambiguous invocation` error that could occur due to the presence of the deprecated library.

**Why This PR Is Necessary:**

With the deprecation of `AutoMapper.Extensions.Microsoft.DependencyInjection`, removing it from the project dependencies is essential to ensure the application can build without encountering errors. By migrating to the main AutoMapper library, we ensure compatibility with future updates and eliminate any ambiguity in method invocations.