### PR TITLE
Updated PostgreSQL migrations & Fixed an JSInterop error

### DIFF
--- a/src/Migrators/Migrators.PostgreSQL/Migrations/20240408110900_AddedDataProtectionKeys.Designer.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/20240408110900_AddedDataProtectionKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CleanArchitecture.Blazor.Migrators.PostgreSQL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240408110900_AddedDataProtectionKeys")]
+    partial class AddedDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/20240408110900_AddedDataProtectionKeys.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/20240408110900_AddedDataProtectionKeys.cs
@@ -1,0 +1,174 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CleanArchitecture.Blazor.Migrators.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_audit_trails_users_owner_id",
+                table: "audit_trails");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "message",
+                table: "loggers",
+                type: "character varying(4000)",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "level",
+                table: "loggers",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "exception",
+                table: "loggers",
+                type: "character varying(4000)",
+                maxLength: 4000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "data_protection_keys",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    friendly_name = table.Column<string>(type: "text", nullable: true),
+                    xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_data_protection_keys", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_loggers_exception",
+                table: "loggers",
+                column: "exception");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_loggers_level",
+                table: "loggers",
+                column: "level");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_loggers_message",
+                table: "loggers",
+                column: "message");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_loggers_time_stamp",
+                table: "loggers",
+                column: "time_stamp");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_asp_net_users_tenant_id",
+                table: "AspNetUsers",
+                column: "tenant_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_asp_net_users_tenants_tenant_id",
+                table: "AspNetUsers",
+                column: "tenant_id",
+                principalTable: "tenants",
+                principalColumn: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_audit_trails_asp_net_users_user_id",
+                table: "audit_trails",
+                column: "user_id",
+                principalTable: "AspNetUsers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_asp_net_users_tenants_tenant_id",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_audit_trails_asp_net_users_user_id",
+                table: "audit_trails");
+
+            migrationBuilder.DropTable(
+                name: "data_protection_keys");
+
+            migrationBuilder.DropIndex(
+                name: "ix_loggers_exception",
+                table: "loggers");
+
+            migrationBuilder.DropIndex(
+                name: "ix_loggers_level",
+                table: "loggers");
+
+            migrationBuilder.DropIndex(
+                name: "ix_loggers_message",
+                table: "loggers");
+
+            migrationBuilder.DropIndex(
+                name: "ix_loggers_time_stamp",
+                table: "loggers");
+
+            migrationBuilder.DropIndex(
+                name: "ix_asp_net_users_tenant_id",
+                table: "AspNetUsers");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "message",
+                table: "loggers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(4000)",
+                oldMaxLength: 4000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "level",
+                table: "loggers",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(450)",
+                oldMaxLength: 450);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "exception",
+                table: "loggers",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(4000)",
+                oldMaxLength: 4000,
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_audit_trails_users_owner_id",
+                table: "audit_trails",
+                column: "user_id",
+                principalTable: "AspNetUsers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/src/Server.UI/Components/Redirections/RedirectToHome.razor
+++ b/src/Server.UI/Components/Redirections/RedirectToHome.razor
@@ -1,10 +1,8 @@
 ﻿@inject IdentityRedirectManager RedirectManager
 
 @code {
-
-    protected override void OnInitialized()
+    protected override void OnAfterRender(bool firstRender)
     {
         RedirectManager.RedirectTo("/");
     }
-
 }

--- a/src/Server.UI/Components/Redirections/RedirectToLogin.razor
+++ b/src/Server.UI/Components/Redirections/RedirectToLogin.razor
@@ -2,7 +2,7 @@
 
 @code {
 
-    protected override void OnInitialized()
+    protected override void OnAfterRender(bool firstRender)
     {
         NavigationManager.NavigateTo("/pages/authentication/login", true);
     }

--- a/src/Server.UI/Components/Shared/Layout/AppLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/AppLayout.razor
@@ -1,17 +1,11 @@
-﻿@using Severity = Severity
-@using Toolbelt.Blazor.HotKeys2
-@using CleanArchitecture.Blazor.Server.UI.Services.UserPreferences
-@using CleanArchitecture.Blazor.Server.UI.Constants
-@layout MainLayout
+﻿@layout MainLayout
 @inherits LayoutComponentBase
 
 @inject LayoutService LayoutService
-@inject HotKeys HotKeys
-@inject IStringLocalizer<SharedResource> L
 <MudLayout>
     <AuthorizeView>
         <NotAuthorized>
-            <RedirectToLogin />
+            <RedirectToLogin/>
         </NotAuthorized>
         <Authorized>
             <HeaderMenu NavigationMenuDrawerOpen="_navigationMenuDrawerOpen"
@@ -20,17 +14,17 @@
                         ToggleNavigationMenuDrawer="ToggleNavigationMenuDrawer"
                         RightToLeft="@LayoutService.IsRTL"
                         RightToLeftToggle="LayoutService.ToggleRightToLeft"
-                        OnSettingClick="@(() => _themingDrawerOpen = true)" />
+                        OnSettingClick="@(() => _themingDrawerOpen = true)"/>
             <NavigationMenu DrawerOpen="_navigationMenuDrawerOpen" Roles="@_userProfile?.AssignedRoles"
-                            DrawerOpenChanged="NavigationMenuDrawerOpenChangedHandler" />
+                            DrawerOpenChanged="NavigationMenuDrawerOpenChangedHandler"/>
             <ThemesMenu ThemingDrawerOpen="_themingDrawerOpen"
                         ThemingDrawerOpenChanged="ThemingDrawerOpenChangedHandler"
                         UserPreferences="@LayoutService.UserPreferences"
-                        UserPreferencesChanged="LayoutService.UpdateUserPreferences" />
-            <ThemesButton OnClick="@(() => _themingDrawerOpen = true)" />
+                        UserPreferencesChanged="LayoutService.UpdateUserPreferences"/>
+            <ThemesButton OnClick="@(() => _themingDrawerOpen = true)"/>
             <MudMainContent>
                 <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="mb-4 mt-4">
-                    <ErrorBoundary @ref="_errorBoundary">
+                    <ErrorBoundary @ref="ErrorBoundary">
                         <ChildContent>
                             <CascadingValue Value="@_userProfile">
                                 @Body
@@ -42,7 +36,7 @@
                     </ErrorBoundary>
                 </MudContainer>
             </MudMainContent>
-            <UserLoginState />
+            <UserLoginState/>
         </Authorized>
     </AuthorizeView>
 </MudLayout>
@@ -54,14 +48,15 @@
     private bool _navigationMenuDrawerOpen = true;
     private bool _themingDrawerOpen;
     private UserProfile? _userProfile;
-    private ErrorBoundary? _errorBoundary { set; get; }
-    [CascadingParameter] 
-    private Task<AuthenticationState> AuthState { get; set; } = default!;
+    private ErrorBoundary? ErrorBoundary { set; get; }
+    [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+
     protected override async Task OnInitializedAsync()
     {
         var state = await AuthState;
         _userProfile = state.User.GetUserProfileFromClaim();
     }
+
     protected override void OnParametersSet()
     {
         ResetBoundary();
@@ -70,7 +65,7 @@
     private void ResetBoundary()
     {
         // On each page navigation, reset any error state
-        _errorBoundary?.Recover();
+        ErrorBoundary?.Recover();
     }
 
     protected void NavigationMenuDrawerOpenChangedHandler(bool state)
@@ -93,13 +88,13 @@
         if (!_commandPaletteOpen)
         {
             var options = new DialogOptions
-                {
-                    NoHeader = true,
-                    MaxWidth = MaxWidth.Medium,
-                    FullWidth = true
-                };
+            {
+                NoHeader = true,
+                MaxWidth = MaxWidth.Medium,
+                FullWidth = true
+            };
 
-            var commandPalette = DialogService.Show<SearchDialog>("", options);
+            var commandPalette = await DialogService.ShowAsync<SearchDialog>("", options);
             _commandPaletteOpen = true;
 
             await commandPalette.Result;

--- a/src/Server.UI/Components/Shared/Layout/MainLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/MainLayout.razor
@@ -1,12 +1,8 @@
-﻿@using Severity = Severity
-@using Toolbelt.Blazor.HotKeys2
-@using CleanArchitecture.Blazor.Server.UI.Services.UserPreferences
-@using CleanArchitecture.Blazor.Server.UI.Constants
+﻿@using CleanArchitecture.Blazor.Server.UI.Constants
 @inherits LayoutComponentBase
+@implements IDisposable
 
 @inject LayoutService LayoutService
-@inject HotKeys HotKeys
-@inject IStringLocalizer<SharedResource> L
 
 <PageTitle>@ApplicationSettings.AppName</PageTitle>
 <MudRTLProvider RightToLeft="@LayoutService.IsRTL">
@@ -18,12 +14,9 @@
 
 @code
 {
-
- 
+    
     private MudThemeProvider _mudThemeProvider = null!;
     private bool _defaultDarkMode;
-
-   
 
     public void Dispose()
     {
@@ -63,7 +56,5 @@
     {
         StateHasChanged();
     }
-
-
-     
+    
 }


### PR DESCRIPTION
- Updated: PostgreSQL migrations to support DataProtectionKeys (currently throws some nice errors when you try and start the application using PostgreSQL)
- Fixed: JSInterop error, because the `MainLayout` didn't inherit the `IDisposable` interface, so the `Dispose` method wasn't called.
- Applied some small refactoring to the `MainLayout` and `AppLayout`.