### PR TITLE
🐛 Either the JSON value is not in a supported format, or is out of bo…

### DIFF
--- a/src/Server.UI/Pages/SystemManagement/Components/LogsLineCharts.razor
+++ b/src/Server.UI/Pages/SystemManagement/Components/LogsLineCharts.razor
@@ -61,7 +61,10 @@
             {
                 Labels = new YAxisLabels
                 {
-                    Formatter = @"function (value) {return Number(value).toLocaleString();}"
+                    Formatter = @"function (value, opts) {
+                                    if(value === undefined) { return ''; }
+                                    return Number(value).toLocaleString();
+                                  }"
                 }
             }
         );
@@ -77,8 +80,10 @@
 
         Options.DataLabels = new DataLabels
         {
-            Formatter = @"function(value, opts) {
-                   return  Number(value).toLocaleString();}"
+                Formatter = @"function (value, opts) {
+                                    if(value === undefined) { return ''; }
+                                    return Number(value).toLocaleString();
+                              }"
         };
 
         Options.Tooltip = new Tooltip


### PR DESCRIPTION
System.FormatException: Either the JSON value is not in a supported format, or is out of bounds for an Int32. at System.Text.Json.ThrowHelper.ThrowFormatException(NumericType numericType) at System.Text.Json.Serialization.Converters.Int32Converter.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options) at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue) at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)