### PR TITLE
Fix: CVE-2024-41131 by updating ImageSharp from 3.1.4 -> 3.1.5

### DIFF
--- a/src/Server.UI/Server.UI.csproj
+++ b/src/Server.UI/Server.UI.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Blazor-Analytics" Version="3.12.0" />
         <PackageReference Include="BlazorDownloadFile" Version="2.4.0.2" />
         <PackageReference Include="BlazorTime" Version="1.0.3" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.7" />
         <PackageReference Include="ActualLab.Fusion.Ext.Services" Version="8.0.8" />
         <PackageReference Include="MudBlazor" Version="7.3.0" />


### PR DESCRIPTION
See: https://github.com/neozhu/CleanArchitectureWithBlazorServer/security/dependabot/7