### PR TITLE
Add Custom Autocomplete Components for TimeZone and Language Selection and Extend ApplicationUser

### DIFF
--- a/src/Application/Common/Security/ChangeUserProfileModel.cs
+++ b/src/Application/Common/Security/ChangeUserProfileModel.cs
@@ -24,7 +24,8 @@ public class ChangeUserProfileModel
     public bool IsActive { get; set; }
     public string? TenantId { get; set; }
     public string? TenantName { get; set; }
-
+    public string? TimeZoneId { get; set; }
+    public string? LanguageCode { get; set; }
     private class Mapping : Profile
     {
         public Mapping()

--- a/src/Application/Common/Security/UserProfile.cs
+++ b/src/Application/Common/Security/UserProfile.cs
@@ -21,4 +21,7 @@ public class UserProfile
 
     public string? TimeZoneId { get; set; }
     public string? LanguageCode { get; set; }
+    public TimeSpan LocalTimeOffset => string.IsNullOrEmpty(TimeZoneId)
+    ? TimeZoneInfo.Local.BaseUtcOffset
+    : TimeZoneInfo.FindSystemTimeZoneById(TimeZoneId).BaseUtcOffset;
 }

--- a/src/Application/Common/Security/UserProfile.cs
+++ b/src/Application/Common/Security/UserProfile.cs
@@ -18,4 +18,7 @@ public class UserProfile
     public bool IsActive { get; set; }
     public string? TenantId { get; set; }
     public string? TenantName { get; set; }
+
+    public string? TimeZoneId { get; set; }
+    public string? LanguageCode { get; set; }
 }

--- a/src/Application/Common/Security/UserProfileStateService.cs
+++ b/src/Application/Common/Security/UserProfileStateService.cs
@@ -55,11 +55,13 @@ public class UserProfileStateService
 
     private void NotifyStateChanged() => OnChange?.Invoke();
 
-    public void UpdateUserProfile(string userName,string? profilePictureDataUrl, string? fullName,string? phoneNumber)
+    public void UpdateUserProfile(string userName,string? profilePictureDataUrl, string? fullName,string? phoneNumber,string? timeZoneId,string? languageCode)
     {
         _userProfile.ProfilePictureDataUrl = profilePictureDataUrl;
         _userProfile.DisplayName = fullName;
         _userProfile.PhoneNumber = phoneNumber;
+        _userProfile.TimeZoneId = timeZoneId;
+        _userProfile.LanguageCode = languageCode;
         RemoveApplicationUserCache(userName);
         NotifyStateChanged();
     }

--- a/src/Application/Features/AuditTrails/Queries/PaginationQuery/AuditTrailsWithPaginationQuery.cs
+++ b/src/Application/Features/AuditTrails/Queries/PaginationQuery/AuditTrailsWithPaginationQuery.cs
@@ -16,7 +16,7 @@ public class AuditTrailsWithPaginationQuery : AuditTrailAdvancedFilter, ICacheab
     public override string ToString()
     {
         return
-            $"Listview:{ListView}-{LocalTimezoneOffset.TotalHours},AuditType:{AuditType},Search:{Keyword},Sort:{SortDirection},OrderBy:{OrderBy},{PageNumber},{PageSize}";
+            $"Listview:{ListView}-{CurrentUser?.UserId},AuditType:{AuditType},Search:{Keyword},Sort:{SortDirection},OrderBy:{OrderBy},{PageNumber},{PageSize}";
     }
 }
 

--- a/src/Application/Features/AuditTrails/Specifications/AuditTrailAdvancedFilter.cs
+++ b/src/Application/Features/AuditTrails/Specifications/AuditTrailAdvancedFilter.cs
@@ -12,7 +12,6 @@ public enum AuditTrailListView
 
 public class AuditTrailAdvancedFilter : PaginationFilter
 {
-    public TimeSpan LocalTimezoneOffset { get; set; }
     public AuditType? AuditType { get; set; }
     public AuditTrailListView ListView { get; set; } = AuditTrailListView.All;
     public UserProfile? CurrentUser { get; set; }

--- a/src/Application/Features/AuditTrails/Specifications/AuditTrailAdvancedSpecification.cs
+++ b/src/Application/Features/AuditTrails/Specifications/AuditTrailAdvancedSpecification.cs
@@ -1,5 +1,4 @@
 ﻿using CleanArchitecture.Blazor.Application.Features.AuditTrails.Queries.PaginationQuery;
-using CleanArchitecture.Blazor.Application.Features.Products.Specifications;
 
 namespace CleanArchitecture.Blazor.Application.Features.AuditTrails.Specifications;
 #nullable disable warnings
@@ -8,8 +7,8 @@ public class AuditTrailAdvancedSpecification : Specification<AuditTrail>
     public AuditTrailAdvancedSpecification(AuditTrailsWithPaginationQuery filter)
     {
         DateTime today = DateTime.UtcNow;
-        var todayrange = today.GetDateRange("TODAY", filter.LocalTimezoneOffset);
-        var last30daysrange = today.GetDateRange("LAST_30_DAYS",filter.LocalTimezoneOffset);
+        var todayrange = today.GetDateRange("TODAY", filter.CurrentUser.LocalTimeOffset);
+        var last30daysrange = today.GetDateRange("LAST_30_DAYS",filter.CurrentUser.LocalTimeOffset);
 
 
 

--- a/src/Application/Features/Contacts/Queries/Pagination/ContactsPaginationQuery.cs
+++ b/src/Application/Features/Contacts/Queries/Pagination/ContactsPaginationQuery.cs
@@ -11,7 +11,7 @@ public class ContactsWithPaginationQuery : ContactAdvancedFilter, ICacheableRequ
 {
     public override string ToString()
     {
-        return $"Listview:{ListView}-{LocalTimezoneOffset.TotalHours}, Search:{Keyword}, {OrderBy}, {SortDirection}, {PageNumber}, {PageSize}";
+        return $"Listview:{ListView}-{CurrentUser?.UserId}, Search:{Keyword}, {OrderBy}, {SortDirection}, {PageNumber}, {PageSize}";
     }
     public string CacheKey => ContactCacheKey.GetPaginationCacheKey($"{this}");
     public MemoryCacheEntryOptions? Options => ContactCacheKey.MemoryCacheEntryOptions;

--- a/src/Application/Features/Contacts/Specifications/ContactAdvancedFilter.cs
+++ b/src/Application/Features/Contacts/Specifications/ContactAdvancedFilter.cs
@@ -20,7 +20,6 @@ public enum ContactListView
 /// </summary>
 public class ContactAdvancedFilter: PaginationFilter
 {
-    public TimeSpan LocalTimezoneOffset { get; set; }
     public ContactListView ListView { get; set; } = ContactListView.All;
     public UserProfile? CurrentUser { get; set; }
 }

--- a/src/Application/Features/Contacts/Specifications/ContactAdvancedSpecification.cs
+++ b/src/Application/Features/Contacts/Specifications/ContactAdvancedSpecification.cs
@@ -12,8 +12,8 @@ public class ContactAdvancedSpecification : Specification<Contact>
     {
 
         DateTime today = DateTime.UtcNow;
-        var todayrange = today.GetDateRange(ContactListView.TODAY.ToString(), filter.LocalTimezoneOffset);
-        var last30daysrange = today.GetDateRange(ContactListView.LAST_30_DAYS.ToString(),filter.LocalTimezoneOffset);
+        var todayrange = today.GetDateRange(ContactListView.TODAY.ToString(), filter.CurrentUser.LocalTimeOffset);
+        var last30daysrange = today.GetDateRange(ContactListView.LAST_30_DAYS.ToString(),filter.CurrentUser.LocalTimeOffset);
 
         Query.Where(q => q.Name != null)
              .Where(filter.Keyword,!string.IsNullOrEmpty(filter.Keyword))

--- a/src/Application/Features/Documents/Queries/PaginationQuery/DocumentsWithPaginationQuery.cs
+++ b/src/Application/Features/Documents/Queries/PaginationQuery/DocumentsWithPaginationQuery.cs
@@ -17,7 +17,7 @@ public class DocumentsWithPaginationQuery : AdvancedDocumentsFilter, ICacheableR
     public override string ToString()
     {
         return
-            $"CurrentUserId:{CurrentUser?.UserId},ListView:{ListView}-{LocalTimezoneOffset.TotalHours},Search:{Keyword},OrderBy:{OrderBy} {SortDirection},{PageNumber},{PageSize}";
+            $"CurrentUserId:{CurrentUser?.UserId},ListView:{ListView},Search:{Keyword},OrderBy:{OrderBy} {SortDirection},{PageNumber},{PageSize}";
     }
 }
 

--- a/src/Application/Features/Documents/Specifications/AdvancedDocumentsFilter.cs
+++ b/src/Application/Features/Documents/Specifications/AdvancedDocumentsFilter.cs
@@ -14,7 +14,6 @@ public enum DocumentListView
 
 public class AdvancedDocumentsFilter : PaginationFilter
 {
-    public TimeSpan LocalTimezoneOffset { get; set; }
     public DocumentListView ListView { get; set; } = DocumentListView.All;
     public UserProfile? CurrentUser { get; set; }
 }

--- a/src/Application/Features/Documents/Specifications/AdvancedDocumentsSpecification.cs
+++ b/src/Application/Features/Documents/Specifications/AdvancedDocumentsSpecification.cs
@@ -6,11 +6,9 @@ public class AdvancedDocumentsSpecification : Specification<Document>
 {
     public AdvancedDocumentsSpecification(AdvancedDocumentsFilter filter)
     {
-
         DateTime today = DateTime.UtcNow;
-        var todayrange = today.GetDateRange("TODAY", filter.LocalTimezoneOffset);
-        var last30daysrange = today.GetDateRange("LAST_30_DAYS", filter.LocalTimezoneOffset);
-
+        var todayrange = today.GetDateRange("TODAY", filter.CurrentUser.LocalTimeOffset);
+        var last30daysrange = today.GetDateRange("LAST_30_DAYS", filter.CurrentUser.LocalTimeOffset);
         Query.Where(p =>
                     (p.CreatedBy == filter.CurrentUser.UserId && p.IsPublic == false) ||
                     (p.IsPublic == true && p.TenantId == filter.CurrentUser.TenantId),

--- a/src/Application/Features/Identity/DTOs/ApplicationUserDto.cs
+++ b/src/Application/Features/Identity/DTOs/ApplicationUserDto.cs
@@ -43,7 +43,10 @@ public class ApplicationUserDto
     [Description("Email Confirmed")] public bool EmailConfirmed { get; set; }
 
     [Description("Status")] public DateTimeOffset? LockoutEnd { get; set; }
-
+    [Description("Time Zone")]
+    public string? TimeZoneId { get; set; }
+    [Description("Language")]
+    public string? LanguageCode { get; set; }
     public UserProfile ToUserProfile()
     {
         return new UserProfile
@@ -60,7 +63,9 @@ public class ApplicationUserDto
             SuperiorId = SuperiorId,
             SuperiorName = Superior?.UserName,
             AssignedRoles = AssignedRoles,
-            DefaultRole = DefaultRole
+            DefaultRole = DefaultRole,
+            TimeZoneId = TimeZoneId,
+            LanguageCode = LanguageCode
         };
     }
 

--- a/src/Application/Features/Identity/DTOs/ApplicationUserDto.cs
+++ b/src/Application/Features/Identity/DTOs/ApplicationUserDto.cs
@@ -45,6 +45,10 @@ public class ApplicationUserDto
     [Description("Status")] public DateTimeOffset? LockoutEnd { get; set; }
     [Description("Time Zone")]
     public string? TimeZoneId { get; set; }
+    [Description("Local Time Offset")]
+    public TimeSpan LocalTimeOffset => string.IsNullOrEmpty(TimeZoneId)
+    ? TimeZoneInfo.Local.BaseUtcOffset
+    : TimeZoneInfo.FindSystemTimeZoneById(TimeZoneId).BaseUtcOffset;
     [Description("Language")]
     public string? LanguageCode { get; set; }
     public UserProfile ToUserProfile()
@@ -79,6 +83,7 @@ public class ApplicationUserDto
         public Mapping()
         {
             CreateMap<ApplicationUser, ApplicationUserDto>(MemberList.None)
+                .ForMember(x => x.LocalTimeOffset, s => s.Ignore())
                 .ForMember(x => x.EmailConfirmed, s => s.MapFrom(y => y.EmailConfirmed))
                 .ForMember(x => x.AssignedRoles, s => s.MapFrom(y => y.UserRoles.Select(r => r.Role.Name)));
         }

--- a/src/Application/Features/Loggers/Queries/PaginationQuery/LogsWithPaginationQuery.cs
+++ b/src/Application/Features/Loggers/Queries/PaginationQuery/LogsWithPaginationQuery.cs
@@ -17,7 +17,7 @@ public class LogsWithPaginationQuery : LoggerAdvancedFilter, ICacheableRequest<P
     public override string ToString()
     {
         return
-            $"Listview:{ListView}-{LocalTimezoneOffset.TotalHours},{Level},Search:{Keyword},OrderBy:{OrderBy} {SortDirection},{PageNumber},{PageSize}";
+            $"Listview:{ListView}-{LocalTimeOffset.TotalHours},{Level},Search:{Keyword},OrderBy:{OrderBy} {SortDirection},{PageNumber},{PageSize}";
     }
 }
 

--- a/src/Application/Features/Loggers/Specifications/LoggerAdvancedFilter.cs
+++ b/src/Application/Features/Loggers/Specifications/LoggerAdvancedFilter.cs
@@ -12,7 +12,7 @@ public enum LogListView
 
 public class LoggerAdvancedFilter : PaginationFilter
 {
-    public TimeSpan LocalTimezoneOffset { get; set; }
+    public TimeSpan LocalTimeOffset { get; set; }
     public LogLevel? Level { get; set; }
     public LogListView ListView { get; set; } = LogListView.LAST_30_DAYS;
 }

--- a/src/Application/Features/Loggers/Specifications/LoggerAdvancedSpecification.cs
+++ b/src/Application/Features/Loggers/Specifications/LoggerAdvancedSpecification.cs
@@ -7,8 +7,8 @@ public class LoggerAdvancedSpecification : Specification<Logger>
     public LoggerAdvancedSpecification(LogsWithPaginationQuery filter)
     {
         DateTime today = DateTime.UtcNow;
-        var todayrange = today.GetDateRange("TODAY", filter.LocalTimezoneOffset);
-        var last30daysrange = today.GetDateRange("LAST_30_DAYS", filter.LocalTimezoneOffset);
+        var todayrange = today.GetDateRange("TODAY", filter.LocalTimeOffset);
+        var last30daysrange = today.GetDateRange("LAST_30_DAYS", filter.LocalTimeOffset);
         // Build query conditions
         Query.Where(p => p.TimeStamp >= todayrange.Start && p.TimeStamp < todayrange.End.AddDays(1),
                 filter.ListView == LogListView.TODAY)

--- a/src/Application/Features/Products/Queries/Pagination/ProductsPaginationQuery.cs
+++ b/src/Application/Features/Products/Queries/Pagination/ProductsPaginationQuery.cs
@@ -21,7 +21,7 @@ public class ProductsWithPaginationQuery : ProductAdvancedFilter, ICacheableRequ
     public override string ToString()
     {
         return
-            $"CurrentUser:{CurrentUser?.UserId},ListView:{ListView}-{LocalTimezoneOffset.TotalHours},Search:{Keyword},Name:{Name},Brand:{Brand},Unit:{Unit},MinPrice:{MinPrice},MaxPrice:{MaxPrice},SortDirection:{SortDirection},OrderBy:{OrderBy},{PageNumber},{PageSize}";
+            $"CurrentUser:{CurrentUser?.UserId},ListView:{ListView},Search:{Keyword},Name:{Name},Brand:{Brand},Unit:{Unit},MinPrice:{MinPrice},MaxPrice:{MaxPrice},SortDirection:{SortDirection},OrderBy:{OrderBy},{PageNumber},{PageSize}";
     }
 }
 

--- a/src/Application/Features/Products/Specifications/ProductAdvancedFilter.cs
+++ b/src/Application/Features/Products/Specifications/ProductAdvancedFilter.cs
@@ -14,6 +14,4 @@ public class ProductAdvancedFilter : PaginationFilter
 
     public UserProfile?
         CurrentUser { get; set; } // <-- This CurrentUser property gets its value from the information of
-
-    public TimeSpan LocalTimezoneOffset { get; set; }
 }

--- a/src/Application/Features/Products/Specifications/ProductAdvancedSpecification.cs
+++ b/src/Application/Features/Products/Specifications/ProductAdvancedSpecification.cs
@@ -5,8 +5,8 @@ public class ProductAdvancedSpecification : Specification<Product>
     public ProductAdvancedSpecification(ProductAdvancedFilter filter)
     {
         DateTime today = DateTime.UtcNow;
-        var todayrange = today.GetDateRange("TODAY",filter.LocalTimezoneOffset);
-        var last30daysrange = today.GetDateRange("LAST_30_DAYS", filter.LocalTimezoneOffset);
+        var todayrange = today.GetDateRange("TODAY",filter.CurrentUser.LocalTimeOffset);
+        var last30daysrange = today.GetDateRange("LAST_30_DAYS", filter.CurrentUser.LocalTimeOffset);
         Query.Where(x => x.Name != null)
             .Where(x => x.Name.Contains(filter.Keyword) || x.Description.Contains(filter.Keyword) ||
                         x.Brand.Contains(filter.Keyword), !string.IsNullOrEmpty(filter.Keyword))

--- a/src/Domain/Common/Entities/BaseAuditableEntity.cs
+++ b/src/Domain/Common/Entities/BaseAuditableEntity.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace CleanArchitecture.Blazor.Domain.Common.Entities;
 
-public abstract class BaseAuditableEntity : BaseEntity
+public abstract class BaseAuditableEntity : BaseEntity, IAuditableEntity
 {
     public virtual DateTime? Created { get; set; }
 
@@ -12,4 +12,15 @@ public abstract class BaseAuditableEntity : BaseEntity
     public virtual DateTime? LastModified { get; set; }
 
     public virtual string? LastModifiedBy { get; set; }
+}
+
+public interface IAuditableEntity
+{
+    DateTime? Created { get; set; }
+
+    string? CreatedBy { get; set; }
+
+   DateTime? LastModified { get; set; }
+
+    string? LastModifiedBy { get; set; }
 }

--- a/src/Domain/Identity/ApplicationRole.cs
+++ b/src/Domain/Identity/ApplicationRole.cs
@@ -1,9 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using CleanArchitecture.Blazor.Domain.Common.Entities;
+
 namespace CleanArchitecture.Blazor.Domain.Identity;
 
-public class ApplicationRole : IdentityRole
+public class ApplicationRole : IdentityRole, IAuditableEntity
 {
     public ApplicationRole()
     {
@@ -21,4 +23,8 @@ public class ApplicationRole : IdentityRole
     public string? Description { get; set; }
     public virtual ICollection<ApplicationRoleClaim> RoleClaims { get; set; }
     public virtual ICollection<ApplicationUserRole> UserRoles { get; set; }
+    public DateTime? Created { get; set; }
+    public string? CreatedBy { get; set; }
+    public DateTime? LastModified { get; set; }
+    public string? LastModifiedBy { get; set; }
 }

--- a/src/Domain/Identity/ApplicationUser.cs
+++ b/src/Domain/Identity/ApplicationUser.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using CleanArchitecture.Blazor.Domain.Common.Entities;
 
 namespace CleanArchitecture.Blazor.Domain.Identity;
 
-public class ApplicationUser : IdentityUser
+public class ApplicationUser : IdentityUser, IAuditableEntity
 {
     public ApplicationUser()
     {
@@ -20,7 +21,7 @@ public class ApplicationUser : IdentityUser
     public string? TenantId { get; set; }
     public virtual Tenant? Tenant { get; set; }
 
-    [Column(TypeName = "text")] public string? ProfilePictureDataUrl { get; set; }
+    public string? ProfilePictureDataUrl { get; set; }
 
     public bool IsActive { get; set; }
     public bool IsLive { get; set; }
@@ -33,4 +34,11 @@ public class ApplicationUser : IdentityUser
 
     public string? SuperiorId { get; set; } = null;
     public ApplicationUser? Superior { get; set; } = null;
+    public DateTime? Created { get; set; }
+    public string? CreatedBy { get; set; }
+    public DateTime? LastModified { get; set; }
+    public string? LastModifiedBy { get; set; }
+
+    public string? TimeZoneId { get; set; }
+    public string? LanguageCode { get; set; }
 }

--- a/src/Infrastructure/Constants/Localization/LocalizationConstants.cs
+++ b/src/Infrastructure/Constants/Localization/LocalizationConstants.cs
@@ -12,47 +12,47 @@ public static class LocalizationConstants
         new()
         {
             Code = "en-US",
-            DisplayName = "English"
+            DisplayName = "English (United States)"
         },
         new()
         {
             Code = "de-DE",
-            DisplayName = "Deutsch"
+            DisplayName = "Deutsch (Deutschland)"
         },
         new()
         {
             Code = "ru-RU",
-            DisplayName = "Russian"
+            DisplayName = "русский (Россия)"
         },
         new()
         {
             Code = "fr-FR",
-            DisplayName = "French"
+            DisplayName = "français (France)"
         },
         new()
         {
             Code = "ja-JP",
-            DisplayName = "Japanese"
+            DisplayName = "日本語 (日本)"
         },
         new()
         {
             Code = "km-KH",
-            DisplayName = "Khmer"
+            DisplayName = "ខ្មែរ (កម្ពុជា)"
         },
         new()
         {
             Code = "ca-ES",
-            DisplayName = "Catalan"
+            DisplayName = "català (Espanya)"
         },
         new()
         {
             Code = "es-ES",
-            DisplayName = "Spanish"
+            DisplayName = "español (España)"
         },
         new()
         {
             Code = "zh-CN",
-            DisplayName = "中文"
+            DisplayName = "中文（简体，中国）"
         },
         new()
         {
@@ -62,7 +62,7 @@ public static class LocalizationConstants
         new()
         {
             Code = "ko-kr",
-            DisplayName = "Korean"
+            DisplayName = "한국어(대한민국)"
         }
     };
 }

--- a/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -149,6 +149,8 @@ public class ApplicationDbContextInitializer
             Email = "admin@example.com",
             EmailConfirmed = true,
             ProfilePictureDataUrl = "https://s.gravatar.com/avatar/78be68221020124c23c665ac54e07074?s=80",
+            LanguageCode="en-US",
+            TimeZoneId= "Asia/Shanghai",
             TwoFactorEnabled = false
         };
 
@@ -161,6 +163,8 @@ public class ApplicationDbContextInitializer
             DisplayName = UserName.Demo,
             Email = "demo@example.com",
             EmailConfirmed = true,
+            LanguageCode = "de-DE",
+            TimeZoneId = "Europe/Berlin",
             ProfilePictureDataUrl = "https://s.gravatar.com/avatar/ea753b0b0f357a41491408307ade445e?s=80"
         };
 

--- a/src/Infrastructure/Persistence/Interceptors/AuditableEntityInterceptor.cs
+++ b/src/Infrastructure/Persistence/Interceptors/AuditableEntityInterceptor.cs
@@ -57,7 +57,7 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
         var tenantId = _currentUserService.TenantId;
         var now = _dateTime.Now;
 
-        foreach (var entry in context.ChangeTracker.Entries<BaseAuditableEntity>())
+        foreach (var entry in context.ChangeTracker.Entries<IAuditableEntity>())
         {
             switch (entry.State)
             {
@@ -83,7 +83,7 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
         }
     }
 
-    private static void SetCreationAuditInfo(BaseAuditableEntity entity, string userId, string tenantId, DateTime now)
+    private static void SetCreationAuditInfo(IAuditableEntity entity, string userId, string tenantId, DateTime now)
     {
         entity.CreatedBy = userId;
         entity.Created = now;
@@ -91,7 +91,7 @@ public class AuditableEntityInterceptor : SaveChangesInterceptor
         if (entity is IMayHaveTenant mayTenant) mayTenant.TenantId = tenantId;
     }
 
-    private static void SetModificationAuditInfo(BaseAuditableEntity entity, string userId, DateTime now)
+    private static void SetModificationAuditInfo(IAuditableEntity entity, string userId, DateTime now)
     {
         entity.LastModifiedBy = userId;
         entity.LastModified = now;

--- a/src/Migrators/Migrators.MSSQL/Migrations/20241007110122_IAuditableEntity_ApplicationUser.Designer.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/20241007110122_IAuditableEntity_ApplicationUser.Designer.cs
@@ -4,6 +4,7 @@ using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241007110122_IAuditableEntity_ApplicationUser")]
+    partial class IAuditableEntity_ApplicationUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -364,21 +367,7 @@ namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
                         .HasMaxLength(450)
                         .HasColumnType("nvarchar(450)");
 
-                    b.Property<DateTime?>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
-
                     b.Property<string>("Description")
-                        .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<DateTime?>("LastModified")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("LastModifiedBy")
                         .HasMaxLength(450)
                         .HasColumnType("nvarchar(450)");
 
@@ -480,10 +469,6 @@ namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
                     b.Property<bool>("IsLive")
                         .HasColumnType("bit");
 
-                    b.Property<string>("LanguageCode")
-                        .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
-
                     b.Property<DateTime?>("LastModified")
                         .HasColumnType("datetime2");
 
@@ -518,7 +503,7 @@ namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
 
                     b.Property<string>("ProfilePictureDataUrl")
                         .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Provider")
                         .HasMaxLength(450)
@@ -540,10 +525,6 @@ namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("TenantId")
-                        .HasMaxLength(450)
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<string>("TimeZoneId")
                         .HasMaxLength(450)
                         .HasColumnType("nvarchar(450)");
 

--- a/src/Migrators/Migrators.MSSQL/Migrations/20241007110122_IAuditableEntity_ApplicationUser.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/20241007110122_IAuditableEntity_ApplicationUser.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class IAuditableEntity_ApplicationUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "AspNetUsers",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModified",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastModifiedBy",
+                table: "AspNetUsers",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedBy",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/src/Migrators/Migrators.MSSQL/Migrations/20241007112447_TimeZoneId_LanguageCode.Designer.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/20241007112447_TimeZoneId_LanguageCode.Designer.cs
@@ -4,6 +4,7 @@ using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241007112447_TimeZoneId_LanguageCode")]
+    partial class TimeZoneId_LanguageCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrators/Migrators.MSSQL/Migrations/20241007112447_TimeZoneId_LanguageCode.cs
+++ b/src/Migrators/Migrators.MSSQL/Migrations/20241007112447_TimeZoneId_LanguageCode.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CleanArchitecture.Blazor.Migrators.MSSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class TimeZoneId_LanguageCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePictureDataUrl",
+                table: "AspNetUsers",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldMaxLength: 450,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LanguageCode",
+                table: "AspNetUsers",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TimeZoneId",
+                table: "AspNetUsers",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "AspNetRoles",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "AspNetRoles",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModified",
+                table: "AspNetRoles",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastModifiedBy",
+                table: "AspNetRoles",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LanguageCode",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TimeZoneId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedBy",
+                table: "AspNetRoles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePictureDataUrl",
+                table: "AspNetUsers",
+                type: "text",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)",
+                oldMaxLength: 450,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/20241007113739_TimeZoneId_LanguageCode.Designer.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/20241007113739_TimeZoneId_LanguageCode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CleanArchitecture.Blazor.Migrators.PostgreSQL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241007113739_TimeZoneId_LanguageCode")]
+    partial class TimeZoneId_LanguageCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrators/Migrators.PostgreSQL/Migrations/20241007113739_TimeZoneId_LanguageCode.cs
+++ b/src/Migrators/Migrators.PostgreSQL/Migrations/20241007113739_TimeZoneId_LanguageCode.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CleanArchitecture.Blazor.Migrators.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class TimeZoneId_LanguageCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "profile_picture_data_url",
+                table: "AspNetUsers",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldMaxLength: 450,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created",
+                table: "AspNetUsers",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "created_by",
+                table: "AspNetUsers",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "language_code",
+                table: "AspNetUsers",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_modified",
+                table: "AspNetUsers",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "last_modified_by",
+                table: "AspNetUsers",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "time_zone_id",
+                table: "AspNetUsers",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created",
+                table: "AspNetRoles",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "created_by",
+                table: "AspNetRoles",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_modified",
+                table: "AspNetRoles",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "last_modified_by",
+                table: "AspNetRoles",
+                type: "character varying(450)",
+                maxLength: 450,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "created",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "created_by",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "language_code",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "last_modified",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "last_modified_by",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "time_zone_id",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "created",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "created_by",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "last_modified",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "last_modified_by",
+                table: "AspNetRoles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "profile_picture_data_url",
+                table: "AspNetUsers",
+                type: "text",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(450)",
+                oldMaxLength: 450,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Migrators/Migrators.SqLite/Migrations/20241007113815_TimeZoneId_LanguageCode.Designer.cs
+++ b/src/Migrators/Migrators.SqLite/Migrations/20241007113815_TimeZoneId_LanguageCode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CleanArchitecture.Blazor.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CleanArchitecture.Blazor.Migrators.SqLite.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241007113815_TimeZoneId_LanguageCode")]
+    partial class TimeZoneId_LanguageCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.8");

--- a/src/Migrators/Migrators.SqLite/Migrations/20241007113815_TimeZoneId_LanguageCode.cs
+++ b/src/Migrators/Migrators.SqLite/Migrations/20241007113815_TimeZoneId_LanguageCode.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CleanArchitecture.Blazor.Migrators.SqLite.Migrations
+{
+    /// <inheritdoc />
+    public partial class TimeZoneId_LanguageCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePictureDataUrl",
+                table: "AspNetUsers",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldMaxLength: 450,
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "AspNetUsers",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "AspNetUsers",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LanguageCode",
+                table: "AspNetUsers",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModified",
+                table: "AspNetUsers",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastModifiedBy",
+                table: "AspNetUsers",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TimeZoneId",
+                table: "AspNetUsers",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "AspNetRoles",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "AspNetRoles",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModified",
+                table: "AspNetRoles",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastModifiedBy",
+                table: "AspNetRoles",
+                type: "TEXT",
+                maxLength: 450,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LanguageCode",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedBy",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TimeZoneId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedBy",
+                table: "AspNetRoles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProfilePictureDataUrl",
+                table: "AspNetUsers",
+                type: "text",
+                maxLength: 450,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldMaxLength: 450,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Server.UI/Components/Autocompletes/LanguageAutocomplete.cs
+++ b/src/Server.UI/Components/Autocompletes/LanguageAutocomplete.cs
@@ -1,24 +1,19 @@
 ﻿using System.Globalization;
-using CleanArchitecture.Blazor.Application.Features.PicklistSets.DTOs;
 
 namespace CleanArchitecture.Blazor.Server.UI.Components.Autocompletes;
 
 public class LanguageAutocomplete<T> : MudAutocomplete<string>
 {
     private List<CultureInfo> Languages { get;  set; }= CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList();
-
-
-
-    public LanguageAutocomplete<T>()
+    public LanguageAutocomplete()
     {
-
         SearchFunc = SearchFunc_;
         Clearable = true;
         Dense = true;
         ResetValueOnEmptyText = true;
         ToStringFunc = x =>
         {
-            var language = Languages.FirstOrDefault(lang => lang.Name == x);
+            var language = Languages.FirstOrDefault(lang => lang.Name.Equals(x));
             return language != null ? $"{language.DisplayName} ({language.Name})" : x;
         };
     }

--- a/src/Server.UI/Components/Autocompletes/LanguageAutocomplete.cs
+++ b/src/Server.UI/Components/Autocompletes/LanguageAutocomplete.cs
@@ -1,20 +1,20 @@
-﻿using System.Globalization;
+﻿using CleanArchitecture.Blazor.Infrastructure.Constants.Localization;
 
 namespace CleanArchitecture.Blazor.Server.UI.Components.Autocompletes;
 
 public class LanguageAutocomplete<T> : MudAutocomplete<string>
 {
-    private List<CultureInfo> Languages { get;  set; }= CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList();
+    
+    private List<LanguageCode> Languages { get; set; }= LocalizationConstants.SupportedLanguages.ToList();
     public LanguageAutocomplete()
     {
         SearchFunc = SearchFunc_;
-        Clearable = true;
         Dense = true;
         ResetValueOnEmptyText = true;
         ToStringFunc = x =>
         {
-            var language = Languages.FirstOrDefault(lang => lang.Name.Equals(x));
-            return language != null ? $"{language.DisplayName} ({language.Name})" : x;
+            var language = Languages.FirstOrDefault(lang =>lang.Code.Equals(x, StringComparison.OrdinalIgnoreCase));
+            return language != null ? $"{language.DisplayName}" : x;
         };
     }
 
@@ -22,15 +22,16 @@ public class LanguageAutocomplete<T> : MudAutocomplete<string>
     {
         // 如果输入为空，返回完整的语言列表；否则进行模糊搜索
         return string.IsNullOrEmpty(value)
-            ? Task.FromResult(Languages.Select(lang => lang.Name).AsEnumerable())
+            ? Task.FromResult(Languages.Select(lang => lang.Code).AsEnumerable())
             : Task.FromResult(Languages
                 .Where(lang => Contains(lang, value))
-                .Select(lang => lang.Name));
+                .Select(lang => lang.Code));
     }
 
-    private static bool Contains(CultureInfo language, string value)
+    private static bool Contains(LanguageCode language, string value)
     {
-        return language.DisplayName.Contains(value, StringComparison.InvariantCultureIgnoreCase) ||
-               language.Name.Contains(value, StringComparison.InvariantCultureIgnoreCase);
+        return language.Code.Contains(value, StringComparison.InvariantCultureIgnoreCase) ||
+                language.DisplayName.Contains(value, StringComparison.InvariantCultureIgnoreCase);
     }
+    
 }

--- a/src/Server.UI/Components/Autocompletes/LanguageAutocomplete.cs
+++ b/src/Server.UI/Components/Autocompletes/LanguageAutocomplete.cs
@@ -1,0 +1,41 @@
+﻿using System.Globalization;
+using CleanArchitecture.Blazor.Application.Features.PicklistSets.DTOs;
+
+namespace CleanArchitecture.Blazor.Server.UI.Components.Autocompletes;
+
+public class LanguageAutocomplete<T> : MudAutocomplete<string>
+{
+    private List<CultureInfo> Languages { get;  set; }= CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList();
+
+
+
+    public LanguageAutocomplete<T>()
+    {
+
+        SearchFunc = SearchFunc_;
+        Clearable = true;
+        Dense = true;
+        ResetValueOnEmptyText = true;
+        ToStringFunc = x =>
+        {
+            var language = Languages.FirstOrDefault(lang => lang.Name == x);
+            return language != null ? $"{language.DisplayName} ({language.Name})" : x;
+        };
+    }
+
+    private Task<IEnumerable<string>> SearchFunc_(string value, CancellationToken cancellation = default)
+    {
+        // 如果输入为空，返回完整的语言列表；否则进行模糊搜索
+        return string.IsNullOrEmpty(value)
+            ? Task.FromResult(Languages.Select(lang => lang.Name).AsEnumerable())
+            : Task.FromResult(Languages
+                .Where(lang => Contains(lang, value))
+                .Select(lang => lang.Name));
+    }
+
+    private static bool Contains(CultureInfo language, string value)
+    {
+        return language.DisplayName.Contains(value, StringComparison.InvariantCultureIgnoreCase) ||
+               language.Name.Contains(value, StringComparison.InvariantCultureIgnoreCase);
+    }
+}

--- a/src/Server.UI/Components/Autocompletes/MultiTenantAutocomplete.razor.cs
+++ b/src/Server.UI/Components/Autocompletes/MultiTenantAutocomplete.razor.cs
@@ -12,7 +12,6 @@ public class MultiTenantAutocomplete<T> : MudAutocomplete<TenantDto>
     {
         SearchFunc = SearchKeyValues;
         ToStringFunc = dto => dto?.Name;
-        Clearable = true;
         Dense = true;
         ResetValueOnEmptyText = true;
         ShowProgressIndicator = true;

--- a/src/Server.UI/Components/Autocompletes/TimeZoneAutocomplete.cs
+++ b/src/Server.UI/Components/Autocompletes/TimeZoneAutocomplete.cs
@@ -1,6 +1,4 @@
-﻿using CleanArchitecture.Blazor.Application.Features.PicklistSets.DTOs;
-
-namespace CleanArchitecture.Blazor.Server.UI.Components.Autocompletes;
+﻿namespace CleanArchitecture.Blazor.Server.UI.Components.Autocompletes;
 
 public class TimeZoneAutocomplete<T> : MudAutocomplete<string>
 {
@@ -12,7 +10,7 @@ public class TimeZoneAutocomplete<T> : MudAutocomplete<string>
         ResetValueOnEmptyText = true;
         ToStringFunc = x =>
         {
-            var timeZone = TimeZones.FirstOrDefault(tz => tz.Id == x);
+            var timeZone = TimeZones.FirstOrDefault(tz => tz.Id.Equals(x));
             return timeZone != null ? timeZone.DisplayName : x;
         };
     }

--- a/src/Server.UI/Components/Autocompletes/TimeZoneAutocomplete.cs
+++ b/src/Server.UI/Components/Autocompletes/TimeZoneAutocomplete.cs
@@ -1,0 +1,34 @@
+﻿using CleanArchitecture.Blazor.Application.Features.PicklistSets.DTOs;
+
+namespace CleanArchitecture.Blazor.Server.UI.Components.Autocompletes;
+
+public class TimeZoneAutocomplete<T> : MudAutocomplete<string>
+{
+    private List<TimeZoneInfo> TimeZones { get; set; }= TimeZoneInfo.GetSystemTimeZones().ToList();
+    public TimeZoneAutocomplete()
+    {
+        SearchFunc = SearchFunc_;
+        Dense = true;
+        ResetValueOnEmptyText = true;
+        ToStringFunc = x =>
+        {
+            var timeZone = TimeZones.FirstOrDefault(tz => tz.Id == x);
+            return timeZone != null ? timeZone.DisplayName : x;
+        };
+    }
+
+    private Task<IEnumerable<string>> SearchFunc_(string value, CancellationToken cancellation = default)
+    {
+        return string.IsNullOrEmpty(value)
+            ? Task.FromResult(TimeZones.Select(tz => tz.Id).AsEnumerable())
+            : Task.FromResult(TimeZones
+                .Where(tz => Contains(tz, value))
+                .Select(tz => tz.Id));
+    }
+
+    private static bool Contains(TimeZoneInfo timeZone, string value)
+    {
+        return timeZone.DisplayName.Contains(value, StringComparison.InvariantCultureIgnoreCase) ||
+               timeZone.Id.Contains(value, StringComparison.InvariantCultureIgnoreCase);
+    }
+}

--- a/src/Server.UI/Components/Shared/Layout/AppLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/AppLayout.razor
@@ -73,6 +73,7 @@
     }
     private async Task UserProfileStateService_OnChange()
     {
+        UserProfile = UserProfileStateService.UserProfile;
         await InvokeAsync(StateHasChanged);
     }
     private void ResetBoundary()

--- a/src/Server.UI/Components/Shared/Layout/AuthenticationLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/AuthenticationLayout.razor
@@ -3,7 +3,6 @@
 @inject IStringLocalizer<SharedResource> L
 <MudRTLProvider>
     <MudThemeProvider Theme="Theme.ApplicationTheme()"/>
-    <MudPopoverProvider />
     <MudLayout>
         <AuthorizeView>
             <NotAuthorized>

--- a/src/Server.UI/Components/Shared/Layout/AuthenticationLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/AuthenticationLayout.razor
@@ -3,6 +3,7 @@
 @inject IStringLocalizer<SharedResource> L
 <MudRTLProvider>
     <MudThemeProvider Theme="Theme.ApplicationTheme()"/>
+    <MudPopoverProvider />
     <MudLayout>
         <AuthorizeView>
             <NotAuthorized>

--- a/src/Server.UI/Components/Shared/Layout/MainLayout.razor
+++ b/src/Server.UI/Components/Shared/Layout/MainLayout.razor
@@ -11,17 +11,15 @@
     <MudDialogProvider />
     <MudSnackbarProvider />
     <MudThemeProvider @ref="@_mudThemeProvider" Theme="@LayoutService.CurrentTheme" IsDarkMode="@LayoutService.IsDarkMode" IsDarkModeChanged="@LayoutService.SetDarkMode" />
-    <CascadingValue Name="LocalTimezoneOffset" Value="@_localTimezoneOffset">
+
         @Body
-    </CascadingValue>
+
 </MudRTLProvider>
 
 @code
 {
-    private TimeSpan _localTimezoneOffset;
     private MudThemeProvider _mudThemeProvider = null!;
     private bool _defaultDarkMode;
-
     public void Dispose()
     {
         LayoutService.MajorUpdateOccured -= LayoutServiceOnMajorUpdateOccured;
@@ -33,7 +31,6 @@
         await base.OnAfterRenderAsync(firstRender);
         if (firstRender)
         {
-            _localTimezoneOffset = await new LocalTimezoneOffset(JS).GetLocalOffset();
             await ApplyUserPreferences();
             StateHasChanged();
         }

--- a/src/Server.UI/Components/Shared/Layout/UserMenu.razor
+++ b/src/Server.UI/Components/Shared/Layout/UserMenu.razor
@@ -84,7 +84,13 @@
     protected override void OnInitialized()
     {
         UserProfileStateService.OnChange += UserProfileStateService_OnChange;
-        antiforgeryToken = getAntiforgeryToken();
+    }
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            antiforgeryToken = getAntiforgeryToken();
+        }
     }
     private string? getAntiforgeryToken()
     {

--- a/src/Server.UI/Components/UtcToLocalTime/UtcToLocal.razor
+++ b/src/Server.UI/Components/UtcToLocalTime/UtcToLocal.razor
@@ -9,6 +9,7 @@ else
     <MudText Class="@Class">@UTCDateTime.ToString(Format)</MudText>
 }
 @code {
+    [CascadingParameter] private UserProfile? UserProfile { get; set; }
     // Parameter to accept the UTC time that needs to be converted
     [Parameter]
     public DateTime UTCDateTime { get; set; }
@@ -24,13 +25,12 @@ else
     private DateTime? localTime;
 
     // This method is called when the component is initialized
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
-        // Call JavaScript function to get the browser's time zone offset in minutes
-        var timezoneOffset = await new LocalTimezoneOffset(JSRuntime).GetLocalOffset();
-
+        var timeOffset = UserProfile?.LocalTimeOffset ?? TimeZoneInfo.Local.BaseUtcOffset;
         // Convert the UTC time to local time by adding the time zone offset
-        localTime = UTCDateTime.Add(timezoneOffset);
+        localTime = UTCDateTime.Add(timeOffset);
+        return Task.CompletedTask;
 
     }
 }

--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -105,7 +105,7 @@ public static class DependencyInjection
             c.BaseAddress = new Uri("http://10.33.1.150:8000/ocr/predict-by-file");
             c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }).AddTransientHttpErrorPolicy(policy => policy.WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(30)));
-        services.AddScoped<LocalTimezoneOffset>();
+        services.AddScoped<LocalTimeOffset>();
         services.AddHttpContextAccessor();
         services.AddScoped<HubClient>();
         services

--- a/src/Server.UI/Pages/Contacts/Contacts.razor
+++ b/src/Server.UI/Pages/Contacts/Contacts.razor
@@ -216,8 +216,7 @@
     private Task<AuthenticationState> AuthState { get; set; } = default!;
     [CascadingParameter]
     private UserProfile? UserProfile { get; set; }
-    [CascadingParameter(Name = "LocalTimezoneOffset")]
-    private TimeSpan _localTimezoneOffset { get; set; }
+
 
     private ContactsWithPaginationQuery Query { get; set; } = new();
     [Inject]
@@ -250,7 +249,6 @@
             Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
-            Query.LocalTimezoneOffset = _localTimezoneOffset;
             var result = await Mediator.Send(Query).ConfigureAwait(false);
             return new GridData<ContactDto>() { TotalItems = result.TotalItems, Items = result.Items };
         }

--- a/src/Server.UI/Pages/Documents/Documents.razor
+++ b/src/Server.UI/Pages/Documents/Documents.razor
@@ -217,10 +217,7 @@
 
 @code {
     [CascadingParameter] protected Task<AuthenticationState> AuthState { get; set; } = default!;
-
     [CascadingParameter] private UserProfile? UserProfile { get; set; }
-    [CascadingParameter(Name = "LocalTimezoneOffset")]
-    private TimeSpan _localTimezoneOffset { get; set; }
     private string? Title { get; set; }
 
     private HashSet<DocumentDto> _selectedItems = new();
@@ -304,7 +301,6 @@
             Query.SortDirection = state.SortDefinitions.FirstOrDefault() == null ? SortDirection.Descending.ToString() : state.SortDefinitions.First().Descending ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
-            Query.LocalTimezoneOffset = _localTimezoneOffset;
             var result = await Mediator.Send(Query);
             return new GridData<DocumentDto> { TotalItems = result.TotalItems, Items = result.Items };
         }

--- a/src/Server.UI/Pages/Identity/Authentication/ExternalLogin.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/ExternalLogin.razor
@@ -3,6 +3,7 @@
 @using System.Text
 @using CleanArchitecture.Blazor.Application.Common.Interfaces.MultiTenant
 @using CleanArchitecture.Blazor.Domain.Identity
+@using CleanArchitecture.Blazor.Infrastructure.Constants.Localization
 @using CleanArchitecture.Blazor.Infrastructure.Constants.Role
 @using Microsoft.AspNetCore.WebUtilities
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.UserActivation
@@ -98,9 +99,9 @@
                                                                                                                                        appearance: none;
                                                                                                                                        background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
                                                                                                                                        background-size: 10px;" aria-required="true">
-                            @foreach (var item in CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList())
+                            @foreach (var item in LocalizationConstants.SupportedLanguages.ToList())
                             {
-                                <option value="@item.Name">@item.DisplayName</option>
+                                <option value="@item.Code">@item.DisplayName</option>
                             }
                         </InputSelect>
                         <div class="mud-input-outlined-border"></div>
@@ -247,7 +248,7 @@
                 Navigation.ToAbsoluteUri(ConfirmEmail.PageUrl).AbsoluteUri,
                 new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code, ["returnUrl"] = "/" });
             await Mediator.Publish(new UserActivationNotification(callbackUrl, Input.Email, userId, Input.Email));
-            RedirectManager.RedirectTo(RegisterConfirmation.PageUrl, new Dictionary<string, object?> { ["email"] = Input.Email });
+            RedirectManager.RedirectTo(RegisterConfirmation.PageUrl);
         }
         // If account confirmation is required, we need to show the link if we don't have a real email sender
         else if (UserManager.Options.SignIn.RequireConfirmedAccount)

--- a/src/Server.UI/Pages/Identity/Authentication/ExternalLogin.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/ExternalLogin.razor
@@ -7,6 +7,7 @@
 @using Microsoft.AspNetCore.WebUtilities
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.UserActivation
 @using System.ComponentModel.DataAnnotations
+@using System.Globalization
 
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
@@ -63,6 +64,52 @@
                 <div class="mud-input-helper-text mud-input-error">
                     <div class="d-flex">
                         <ValidationMessage For="() => Input.Email" class="mud-input-error"/>
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.TimeZoneId" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var item in TimeZoneInfo.GetSystemTimeZones().ToList())
+                            {
+                                <option value="@item.Id">@item.DisplayName</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Time Zone"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.TimeZoneId" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.LanguageCode" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var item in CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList())
+                            {
+                                <option value="@item.Name">@item.DisplayName</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Language"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.LanguageCode" class="mud-input-error" />
                     </div>
                 </div>
             </div>
@@ -161,6 +208,8 @@
         var emailStore = GetEmailStore();
         var user = CreateUser();
         user.TenantId=Input.TenantId;
+        user.TimeZoneId=Input.TimeZoneId;
+        user.LanguageCode=Input.LanguageCode;
         await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
         await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
         user.Provider = externalLoginInfo.LoginProvider;
@@ -242,6 +291,10 @@
     {
         [Required] [EmailAddress] public string Email { get; set; } = "";
         [Required] public string TenantId { get; set; } = "";
+        [Display(Name = "Time Zone")]
+        public string? TimeZoneId { get; set; } = TimeZoneInfo.Local.Id;
+        [Display(Name = "Language")]
+        public string? LanguageCode { get; set; } = CultureInfo.CurrentCulture.Name;
     }
 
 }

--- a/src/Server.UI/Pages/Identity/Authentication/Forgot.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Forgot.razor
@@ -1,22 +1,40 @@
-﻿@page "/pages/forgot-password"
+﻿@page "/pages/authentication/forgot-password"
 @using CleanArchitecture.Blazor.Domain.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using System.Text
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.ResetPassword
 @using System.ComponentModel.DataAnnotations
-@inherits OwningComponentBase
+
 @inject IStringLocalizer<Forgot> L
 @inject ILogger<Forgot> Logger
+@inject IdentityRedirectManager RedirectManager
+@inject UserManager<ApplicationUser> UserManager
 <PageTitle>@Title</PageTitle>
 
-<EditForm Model="Input"  OnValidSubmit="OnValidSubmitAsync">
+<EditForm Model="Input" FormName="forgot-password" OnValidSubmit="OnValidSubmitAsync" method="post">
     <DataAnnotationsValidator/>
 
     <MudText Typo="Typo.h4" GutterBottom="true">@L["Forgot Password?"]</MudText>
     <MudText Typo="Typo.body1">@L["No worries! Just enter your email address below and we'll send you a link to reset your password."]</MudText>
-    <StatusMessage Message="@Message" Error="true" />
-    <MudTextField For="(()=>Input.Email)" Variant="Variant.Outlined" Label="@L["E-mail"]" @bind-Value="Input.Email" Required></MudTextField>
-     
+    <StatusMessage Message="@Message" Error="true"/>
+    <div class="mud-input-control mud-input-input-control my-4">
+        <div class="mud-input-control-input-container">
+            <!--!--><!--!-->
+            <div class="mud-input mud-input-outlined mud-shrink">
+                <InputText @bind-Value="Input.Email" class="mud-input-slot mud-input-root mud-input-root-outlined" type="text" autocomplete="email" aria-required="true" placeholder="name@example.com"/>
+                <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
+                <!--!-->
+                <div class="mud-input-outlined-border"></div>
+            </div>
+            <!--!-->
+            <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="userName">@L["E-mail"]</label>
+        </div>
+        <div class="mud-input-helper-text mud-input-error">
+            <div class="d-flex">
+                <ValidationMessage For="() => Input.Email" class="mud-input-error"/>
+            </div>
+        </div>
+    </div>
     <MudButton Variant="Variant.Filled"
                Color="Color.Primary"
                Size="Size.Large"
@@ -28,21 +46,18 @@
 </EditForm>
 
 @code {
-    public const string PageUrl = "/pages/forgot-password";
+    public const string PageUrl = "/pages/authentication/forgot-password";
     public string Title = "Forgot Password";
-    UserManager<ApplicationUser> UserManager;
+
     [SupplyParameterFromForm] private InputModel Input { get; set; } = new();
     private readonly string _resetPasswordToken = string.Empty;
     private string _inputToken = string.Empty;
     private string? Message;
-    private void InitializeServices()
-    {
-        UserManager = ScopedServices.GetRequiredService<UserManager<ApplicationUser>>();
-    }
+
     protected override Task OnInitializedAsync()
     {
         Title = L["Forgot Password"];
-        InitializeServices();
+
         return base.OnInitializedAsync();
     }
 
@@ -68,7 +83,7 @@
             new Dictionary<string, object?> { ["userId"] = user.Id, ["token"] = code });
         await Mediator.Publish(new ResetPasswordNotification(callbackUrl, user.Email!, user.UserName!));
         Logger.LogInformation("Rest password email sent to {0}.", Input.Email);
-        Navigation.NavigateTo(ForgotPasswordConfirmation.PageUrl);
+        RedirectManager.RedirectTo(ForgotPasswordConfirmation.PageUrl);
     }
 
 

--- a/src/Server.UI/Pages/Identity/Authentication/Forgot.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Forgot.razor
@@ -1,40 +1,22 @@
-﻿@page "/pages/authentication/forgot-password"
+﻿@page "/pages/forgot-password"
 @using CleanArchitecture.Blazor.Domain.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using System.Text
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.ResetPassword
 @using System.ComponentModel.DataAnnotations
-
+@inherits OwningComponentBase
 @inject IStringLocalizer<Forgot> L
 @inject ILogger<Forgot> Logger
-@inject IdentityRedirectManager RedirectManager
-@inject UserManager<ApplicationUser> UserManager
 <PageTitle>@Title</PageTitle>
 
-<EditForm Model="Input" FormName="forgot-password" OnValidSubmit="OnValidSubmitAsync" method="post">
+<EditForm Model="Input"  OnValidSubmit="OnValidSubmitAsync">
     <DataAnnotationsValidator/>
 
     <MudText Typo="Typo.h4" GutterBottom="true">@L["Forgot Password?"]</MudText>
     <MudText Typo="Typo.body1">@L["No worries! Just enter your email address below and we'll send you a link to reset your password."]</MudText>
-    <StatusMessage Message="@Message" Error="true"/>
-    <div class="mud-input-control mud-input-input-control my-4">
-        <div class="mud-input-control-input-container">
-            <!--!--><!--!-->
-            <div class="mud-input mud-input-outlined mud-shrink">
-                <InputText @bind-Value="Input.Email" class="mud-input-slot mud-input-root mud-input-root-outlined" type="text" autocomplete="email" aria-required="true" placeholder="name@example.com"/>
-                <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
-                <!--!-->
-                <div class="mud-input-outlined-border"></div>
-            </div>
-            <!--!-->
-            <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="userName">@L["E-mail"]</label>
-        </div>
-        <div class="mud-input-helper-text mud-input-error">
-            <div class="d-flex">
-                <ValidationMessage For="() => Input.Email" class="mud-input-error"/>
-            </div>
-        </div>
-    </div>
+    <StatusMessage Message="@Message" Error="true" />
+    <MudTextField For="(()=>Input.Email)" Variant="Variant.Outlined" Label="@L["E-mail"]" @bind-Value="Input.Email" Required></MudTextField>
+     
     <MudButton Variant="Variant.Filled"
                Color="Color.Primary"
                Size="Size.Large"
@@ -46,18 +28,21 @@
 </EditForm>
 
 @code {
-    public const string PageUrl = "/pages/authentication/forgot-password";
+    public const string PageUrl = "/pages/forgot-password";
     public string Title = "Forgot Password";
-
+    UserManager<ApplicationUser> UserManager;
     [SupplyParameterFromForm] private InputModel Input { get; set; } = new();
     private readonly string _resetPasswordToken = string.Empty;
     private string _inputToken = string.Empty;
     private string? Message;
-
+    private void InitializeServices()
+    {
+        UserManager = ScopedServices.GetRequiredService<UserManager<ApplicationUser>>();
+    }
     protected override Task OnInitializedAsync()
     {
         Title = L["Forgot Password"];
-
+        InitializeServices();
         return base.OnInitializedAsync();
     }
 
@@ -83,7 +68,7 @@
             new Dictionary<string, object?> { ["userId"] = user.Id, ["token"] = code });
         await Mediator.Publish(new ResetPasswordNotification(callbackUrl, user.Email!, user.UserName!));
         Logger.LogInformation("Rest password email sent to {0}.", Input.Email);
-        RedirectManager.RedirectTo(ForgotPasswordConfirmation.PageUrl);
+        Navigation.NavigateTo(ForgotPasswordConfirmation.PageUrl);
     }
 
 

--- a/src/Server.UI/Pages/Identity/Authentication/ForgotPasswordConfirmation.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/ForgotPasswordConfirmation.razor
@@ -1,4 +1,4 @@
-﻿@page "/pages/authentication/forgotpasswordconfirmation"
+﻿@page "/pages/forgotpasswordconfirmation"
 
 @inject IStringLocalizer<ForgotPasswordConfirmation> L
 @inject ILogger<ForgotPasswordConfirmation> Logger
@@ -11,7 +11,7 @@
 
 
 @code {
-    public const string PageUrl = "/pages/authentication/forgotpasswordconfirmation";
+    public const string PageUrl = "/pages/forgotpasswordconfirmation";
     public string Title = "Forgot password confirmation";
 
     protected override void OnInitialized()

--- a/src/Server.UI/Pages/Identity/Authentication/ForgotPasswordConfirmation.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/ForgotPasswordConfirmation.razor
@@ -1,4 +1,4 @@
-﻿@page "/pages/forgotpasswordconfirmation"
+﻿@page "/pages/authentication/forgotpasswordconfirmation"
 
 @inject IStringLocalizer<ForgotPasswordConfirmation> L
 @inject ILogger<ForgotPasswordConfirmation> Logger
@@ -11,7 +11,7 @@
 
 
 @code {
-    public const string PageUrl = "/pages/forgotpasswordconfirmation";
+    public const string PageUrl = "/pages/authentication/forgotpasswordconfirmation";
     public string Title = "Forgot password confirmation";
 
     protected override void OnInitialized()

--- a/src/Server.UI/Pages/Identity/Authentication/Login.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Login.razor
@@ -108,6 +108,7 @@
             await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
         }
     }
+
     private void RedirectTo(string redirectionUrl)
     {
         ArgumentNullException.ThrowIfNull(HttpContext);
@@ -134,8 +135,13 @@
         var result = await SignInManager.PasswordSignInAsync(Input.UserName, Input.Password, Input.RememberMe, true);
         if (result.Succeeded)
         {
+            // Set the language cookie if user.LanguageCode is not null or empty
             Logger.LogInformation("{UserName} has logged in.",Input.UserName);
-            RedirectTo(ReturnUrl??"/");
+            // Determine the language code (use user's language preference or a default value)
+            string languageCode = user.LanguageCode ?? "en-US"; 
+            // Redirect to the desired URL with the culture as a query parameter
+            string redirectUrl = $"{ReturnUrl ?? "/"}?culture={languageCode}";
+            RedirectTo(redirectUrl);
         }
         else if (result.RequiresTwoFactor)
         {

--- a/src/Server.UI/Pages/Identity/Authentication/Register.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Register.razor
@@ -7,6 +7,7 @@
 @using System.Text
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.UserActivation
 @using System.ComponentModel.DataAnnotations
+@using System.Globalization
 
 @inject UserManager<ApplicationUser> UserManager
 @inject IStringLocalizer<Register> L
@@ -33,7 +34,7 @@
                                                                                                                                        width:100%; 
                                                                                                                                        appearance: none;
                                                                                                                                        background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
-                                                                                                                                        background-size: 10px;" aria-required="true">
+                                                                                                                                       background-size: 10px;" aria-required="true">
                             @foreach (var tenant in TenantsService.DataSource)
                             {
                                 <option value="@tenant.Id">@tenant.Name</option>
@@ -124,7 +125,52 @@
                     </div>
                 </div>
             </div>
-
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.TimeZoneId" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var item in TimeZoneInfo.GetSystemTimeZones().ToList())
+                            {
+                                <option value="@item.Id">@item.DisplayName</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Time Zone"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.TimeZoneId" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.LanguageCode" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var item in CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList())
+                            {
+                                <option value="@item.Name">@item.DisplayName</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Language"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.LanguageCode" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
             <div Class="d-flex justify-space-between align-center mb-1">
                 <label class="form-label">
                     <InputCheckbox @bind-Value="Input.AgreeToTerms" class="form-check-input" />
@@ -170,6 +216,8 @@
     {
         var user = CreateUser();
         user.TenantId = Input.TenantId;
+        user.LanguageCode = Input.LanguageCode;
+        user.TimeZoneId = Input.TimeZoneId;
         await UserStore.SetUserNameAsync(user, Input.UserName, CancellationToken.None);
         var emailStore = GetEmailStore();
         await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
@@ -268,6 +316,10 @@
         [Required]
         [Display(Name = "Tenant Id")]
         public string TenantId { get; set; } = "";
+        [Display(Name = "Time Zone")]
+        public string? TimeZoneId { get; set; } = TimeZoneInfo.Local.Id;
+        [Display(Name = "Language")]
+        public string? LanguageCode { get; set; } = CultureInfo.CurrentCulture.Name;
     }
 
 }

--- a/src/Server.UI/Pages/Identity/Authentication/Register.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Register.razor
@@ -1,4 +1,4 @@
-﻿@page "/pages/authentication/register"
+﻿@page "/pages/register"
 @using CleanArchitecture.Blazor.Application.Common.Interfaces.MultiTenant
 @using CleanArchitecture.Blazor.Application.Features.Tenants.DTOs
 @using CleanArchitecture.Blazor.Domain.Identity
@@ -8,180 +8,38 @@
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.UserActivation
 @using System.ComponentModel.DataAnnotations
 @using System.Globalization
-
-@inject UserManager<ApplicationUser> UserManager
+@inherits OwningComponentBase
 @inject IStringLocalizer<Register> L
 @inject ILogger<Register> Logger
-@inject IUserStore<ApplicationUser> UserStore
-@inject SignInManager<ApplicationUser> SignInManager
-@inject IdentityRedirectManager RedirectManager
 @inject ITenantService TenantsService
 <PageTitle>@Title</PageTitle>
 
 <div class="d-flex flex-column gap-y-3">
     <div class="d-flex flex-column">
-        <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
+        <EditForm Model="Input" OnValidSubmit="RegisterUser">
             <DataAnnotationsValidator />
             <MudText Typo="Typo.h4" GutterBottom="true">@L["Sign Up"]</MudText>
             <MudText>
                 @L["Have an account?"] <MudLink Href="@Login.PageUrl">@L["Sign In"]</MudLink>
             </MudText>
-            <StatusMessage Error="true" Message="@message"></StatusMessage>
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputSelect @bind-Value="Input.TenantId" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
-                                                                                                                                       width:100%; 
-                                                                                                                                       appearance: none;
-                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
-                                                                                                                                       background-size: 10px;" aria-required="true">
-                            @foreach (var tenant in TenantsService.DataSource)
-                            {
-                                <option value="@tenant.Id">@tenant.Name</option>
-                            }
-                        </InputSelect>
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Tenant"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.TenantId" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
 
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <!--!--><!--!-->
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputText @bind-Value="Input.UserName" class="mud-input-slot mud-input-root mud-input-root-outlined" type="text" autocomplete="username" aria-required="true" placeholder="user name" />
-                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
-                        <!--!-->
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <!--!-->
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="userName">@L["User Name"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.UserName" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
+            <MudStack Spacing="2">
+                <MultiTenantAutocomplete For="@(() => Input.Tenant)"
+                                         Variant="Variant.Outlined"
+                                         T="TenantDto"
+                                         Label="@L["Tenant"]"
+                                         Required="true"
+                                         @bind-Value="@Input.Tenant">
 
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <!--!--><!--!-->
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputText @bind-Value="Input.Email" class="mud-input-slot mud-input-root mud-input-root-outlined" type="text" autocomplete="username" aria-required="true" placeholder="user name" />
-                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
-                        <!--!-->
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <!--!-->
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="userName">@L["E-mail"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.Email" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
-
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <!--!--><!--!-->
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputText type="password" @bind-Value="Input.Password" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="current-password" aria-required="true" placeholder="password" />
-                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
-                        <!--!-->
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <!--!-->
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="password">@L["Password"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.Password" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <!--!--><!--!-->
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputText type="password" @bind-Value="Input.ConfirmPassword" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="current-password" aria-required="true" placeholder="Confirm password" />
-                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
-                        <!--!-->
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <!--!-->
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="password">@L["Confirm Password"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.ConfirmPassword" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputSelect @bind-Value="Input.TimeZoneId" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
-                                                                                                                                       width:100%; 
-                                                                                                                                       appearance: none;
-                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
-                                                                                                                                       background-size: 10px;" aria-required="true">
-                            @foreach (var item in TimeZoneInfo.GetSystemTimeZones().ToList())
-                            {
-                                <option value="@item.Id">@item.DisplayName</option>
-                            }
-                        </InputSelect>
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Time Zone"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.TimeZoneId" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
-            <div class="mud-input-control mud-input-input-control my-4">
-                <div class="mud-input-control-input-container">
-                    <div class="mud-input mud-input-outlined mud-shrink">
-                        <InputSelect @bind-Value="Input.LanguageCode" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
-                                                                                                                                       width:100%; 
-                                                                                                                                       appearance: none;
-                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
-                                                                                                                                       background-size: 10px;" aria-required="true">
-                            @foreach (var item in CultureInfo.GetCultures(CultureTypes.SpecificCultures).ToList())
-                            {
-                                <option value="@item.Name">@item.DisplayName</option>
-                            }
-                        </InputSelect>
-                        <div class="mud-input-outlined-border"></div>
-                    </div>
-                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Language"]</label>
-                </div>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.LanguageCode" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
-            <div Class="d-flex justify-space-between align-center mb-1">
-                <label class="form-label">
-                    <InputCheckbox @bind-Value="Input.AgreeToTerms" class="form-check-input" />
-                    @L["I agree to the terms and privacy"]
-                </label>
-                <div class="mud-input-helper-text mud-input-error">
-                    <div class="d-flex">
-                        <ValidationMessage For="() => Input.AgreeToTerms" class="mud-input-error" />
-                    </div>
-                </div>
-            </div>
+                </MultiTenantAutocomplete>
+                <MudTextField For="@(() => Input.UserName)" @bind-Value="Input.UserName" Label="@L["User Name"]" Variant="Variant.Outlined" Required="true"></MudTextField>
+                <MudTextField For="@(() => Input.Email)" @bind-Value="Input.Email" Label="@L["E-mail"]" Variant="Variant.Outlined" Required="true"></MudTextField>
+                <MudTextField For="@(() => Input.Password)" @bind-Value="Input.Password" InputType="InputType.Password" Label="@L["Password"]" Variant="Variant.Outlined" Required="true"></MudTextField>
+                <MudTextField For="@(() => Input.ConfirmPassword)" @bind-Value="Input.ConfirmPassword" InputType="InputType.Password" Label="@L["Confirm Password"]" Variant="Variant.Outlined" Required="true"></MudTextField>
+                <TimeZoneAutocomplete T="string" For="@(() => Input.TimeZoneId)" @bind-Value="Input.TimeZoneId" Label="@L["Time Zone"]" Variant="Variant.Outlined"></TimeZoneAutocomplete>
+                <LanguageAutocomplete T="string" For="@(() => Input.LanguageCode)" @bind-Value="Input.LanguageCode" Label="@L["Time Zone"]" Variant="Variant.Outlined"></LanguageAutocomplete>
+                <MudCheckBox For="@(() => Input.AgreeToTerms)" @bind-Value="Input.AgreeToTerms" Label="@L["I agree to the terms and privacy"]"></MudCheckBox>
+            </MudStack>
 
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
@@ -195,8 +53,12 @@
 </div>
 
 @code {
+    UserManager<ApplicationUser> UserManager;
+    IUserStore<ApplicationUser> UserStore;
+    SignInManager<ApplicationUser> SignInManager;
 
-    public const string PageUrl = "/pages/authentication/register";
+
+    public const string PageUrl = "/pages/register";
     private string Title = "Sign Up";
 
     [SupplyParameterFromQuery] private string? ReturnUrl { get; set; }
@@ -204,18 +66,23 @@
 
 
     [SupplyParameterFromForm] private InputModel Input { get; set; } = new();
-
+    private void InitializeServices()
+    {
+        UserStore = ScopedServices.GetRequiredService<IUserStore<ApplicationUser>>();
+        UserManager = ScopedServices.GetRequiredService<UserManager<ApplicationUser>>();
+        SignInManager = ScopedServices.GetRequiredService<SignInManager<ApplicationUser>>();
+    }
     protected override void OnInitialized()
     {
         Title = L["Sign Up"];
-
+        InitializeServices();
 
     }
 
     public async Task RegisterUser(EditContext editContext)
     {
         var user = CreateUser();
-        user.TenantId = Input.TenantId;
+        user.TenantId = Input.Tenant.Id;
         user.LanguageCode = Input.LanguageCode;
         user.TimeZoneId = Input.TimeZoneId;
         await UserStore.SetUserNameAsync(user, Input.UserName, CancellationToken.None);
@@ -239,7 +106,7 @@
         Logger.LogInformation("New user account created. Username: {UserName}, User ID: {UserId}, Tenant ID: {TenantId}, Assigned Role: {RoleName}.",
             Input.UserName,
             userId,
-            Input.TenantId,
+            Input.Tenant.Id,
             RoleName.Basic);
         if (UserManager.Options.SignIn.RequireConfirmedEmail)
         {
@@ -249,20 +116,11 @@
                 Navigation.ToAbsoluteUri(ConfirmEmail.PageUrl).AbsoluteUri,
                 new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code, ["returnUrl"] = "/" });
             await Mediator.Publish(new UserActivationNotification(callbackUrl, Input.Email, userId, Input.UserName));
-            RedirectManager.RedirectTo(RegisterConfirmation.PageUrl, new Dictionary<string, object?> { ["email"] = Input.Email });
+            Navigation.NavigateTo(RegisterConfirmation.PageUrl);
         }
-        else if (UserManager.Options.SignIn.RequireConfirmedAccount)
-        {
-            var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
-            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-            var callbackUrl = Navigation.GetUriWithQueryParameters(
-                Navigation.ToAbsoluteUri(ConfirmEmail.PageUrl).AbsoluteUri,
-                new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
-            RedirectManager.RedirectTo(RegisterConfirmation.PageUrl, new Dictionary<string, object?> { ["email"] = Input.Email, ["EmailConfirmationLink"] = callbackUrl });
-        }
-
-        await SignInManager.SignInAsync(user, false);
-        RedirectManager.RedirectTo(ReturnUrl);
+        
+        await SignInManager.SignInAsync(user, true);
+        Navigation.NavigateTo(ReturnUrl??"/");
     }
 
     private ApplicationUser CreateUser()
@@ -313,13 +171,13 @@
         [Range(typeof(bool), "true", "true", ErrorMessage = "You must agree to the terms.")]
         public bool AgreeToTerms { get; set; } = true;
 
-        [Required]
-        [Display(Name = "Tenant Id")]
-        public string TenantId { get; set; } = "";
         [Display(Name = "Time Zone")]
         public string? TimeZoneId { get; set; } = TimeZoneInfo.Local.Id;
         [Display(Name = "Language")]
         public string? LanguageCode { get; set; } = CultureInfo.CurrentCulture.Name;
+        [Required]
+        [Display(Name = "Tenant")]
+        public TenantDto? Tenant { get; set; }
     }
 
 }

--- a/src/Server.UI/Pages/Identity/Authentication/Register.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Register.razor
@@ -24,6 +24,7 @@
             </MudText>
 
             <MudStack Spacing="2">
+                <StatusMessage Message="@message" Error="true" />
                 <MultiTenantAutocomplete For="@(() => Input.Tenant)"
                                          Variant="Variant.Outlined"
                                          T="TenantDto"

--- a/src/Server.UI/Pages/Identity/Authentication/Register.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/Register.razor
@@ -1,46 +1,188 @@
-﻿@page "/pages/register"
+﻿@page "/pages/authentication/register"
 @using CleanArchitecture.Blazor.Application.Common.Interfaces.MultiTenant
 @using CleanArchitecture.Blazor.Application.Features.Tenants.DTOs
 @using CleanArchitecture.Blazor.Domain.Identity
+@using CleanArchitecture.Blazor.Infrastructure.Constants.Localization
 @using CleanArchitecture.Blazor.Infrastructure.Constants.Role
 @using Microsoft.AspNetCore.WebUtilities
 @using System.Text
 @using CleanArchitecture.Blazor.Application.Features.Identity.Notifications.UserActivation
 @using System.ComponentModel.DataAnnotations
 @using System.Globalization
-@inherits OwningComponentBase
+
+@inject UserManager<ApplicationUser> UserManager
 @inject IStringLocalizer<Register> L
 @inject ILogger<Register> Logger
+@inject IUserStore<ApplicationUser> UserStore
+@inject SignInManager<ApplicationUser> SignInManager
+@inject IdentityRedirectManager RedirectManager
 @inject ITenantService TenantsService
 <PageTitle>@Title</PageTitle>
 
 <div class="d-flex flex-column gap-y-3">
     <div class="d-flex flex-column">
-        <EditForm Model="Input" OnValidSubmit="RegisterUser">
+        <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
             <DataAnnotationsValidator />
             <MudText Typo="Typo.h4" GutterBottom="true">@L["Sign Up"]</MudText>
             <MudText>
                 @L["Have an account?"] <MudLink Href="@Login.PageUrl">@L["Sign In"]</MudLink>
             </MudText>
+            <StatusMessage Error="true" Message="@message"></StatusMessage>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.TenantId" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var tenant in TenantsService.DataSource)
+                            {
+                                <option value="@tenant.Id">@tenant.Name</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Tenant"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.TenantId" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <!--!--><!--!-->
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputText @bind-Value="Input.UserName" class="mud-input-slot mud-input-root mud-input-root-outlined" type="text" autocomplete="username" aria-required="true" placeholder="user name" />
+                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
+                        <!--!-->
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <!--!-->
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="userName">@L["User Name"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.UserName" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
 
-            <MudStack Spacing="2">
-                <StatusMessage Message="@message" Error="true" />
-                <MultiTenantAutocomplete For="@(() => Input.Tenant)"
-                                         Variant="Variant.Outlined"
-                                         T="TenantDto"
-                                         Label="@L["Tenant"]"
-                                         Required="true"
-                                         @bind-Value="@Input.Tenant">
 
-                </MultiTenantAutocomplete>
-                <MudTextField For="@(() => Input.UserName)" @bind-Value="Input.UserName" Label="@L["User Name"]" Variant="Variant.Outlined" Required="true"></MudTextField>
-                <MudTextField For="@(() => Input.Email)" @bind-Value="Input.Email" Label="@L["E-mail"]" Variant="Variant.Outlined" Required="true"></MudTextField>
-                <MudTextField For="@(() => Input.Password)" @bind-Value="Input.Password" InputType="InputType.Password" Label="@L["Password"]" Variant="Variant.Outlined" Required="true"></MudTextField>
-                <MudTextField For="@(() => Input.ConfirmPassword)" @bind-Value="Input.ConfirmPassword" InputType="InputType.Password" Label="@L["Confirm Password"]" Variant="Variant.Outlined" Required="true"></MudTextField>
-                <TimeZoneAutocomplete T="string" For="@(() => Input.TimeZoneId)" @bind-Value="Input.TimeZoneId" Label="@L["Time Zone"]" Variant="Variant.Outlined"></TimeZoneAutocomplete>
-                <LanguageAutocomplete T="string" For="@(() => Input.LanguageCode)" @bind-Value="Input.LanguageCode" Label="@L["Time Zone"]" Variant="Variant.Outlined"></LanguageAutocomplete>
-                <MudCheckBox For="@(() => Input.AgreeToTerms)" @bind-Value="Input.AgreeToTerms" Label="@L["I agree to the terms and privacy"]"></MudCheckBox>
-            </MudStack>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <!--!--><!--!-->
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputText @bind-Value="Input.Email" class="mud-input-slot mud-input-root mud-input-root-outlined" type="text" autocomplete="username" aria-required="true" placeholder="user name" />
+                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
+                        <!--!-->
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <!--!-->
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="userName">@L["E-mail"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.Email" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <!--!--><!--!-->
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputText type="password" @bind-Value="Input.Password" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="current-password" aria-required="true" placeholder="password" />
+                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
+                        <!--!-->
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <!--!-->
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="password">@L["Password"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.Password" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <!--!--><!--!-->
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputText type="password" @bind-Value="Input.ConfirmPassword" class="mud-input-slot mud-input-root mud-input-root-outlined" autocomplete="current-password" aria-required="true" placeholder="Confirm password" />
+                        <div class="mud-input-slot mud-input-root mud-input-root-outlined" style="display:none"></div>
+                        <!--!-->
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <!--!-->
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="password">@L["Confirm Password"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.ConfirmPassword" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.TimeZoneId" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var item in TimeZoneInfo.GetSystemTimeZones().ToList())
+                            {
+                                <option value="@item.Id">@item.DisplayName</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Time Zone"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.TimeZoneId" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div class="mud-input-control mud-input-input-control my-4">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-input mud-input-outlined mud-shrink">
+                        <InputSelect @bind-Value="Input.LanguageCode" class="mud-input-slot mud-input-root mud-input-root-outlined" style="padding: 18.5px 14px;
+                                                                                                                                       width:100%; 
+                                                                                                                                       appearance: none;
+                                                                                                                                       background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNiAxNic+PHBhdGggZmlsbD0nbm9uZScgc3Ryb2tlPScjMzQzYTQwJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnIHN0cm9rZS13aWR0aD0nMicgZD0nTTIgNWw2IDYgNi02Jy8+PC9zdmc+') no-repeat right 10px center;
+                                                                                                                                       background-size: 10px;" aria-required="true">
+                            @foreach (var item in LocalizationConstants.SupportedLanguages.ToList())
+                            {
+                                <option value="@item.Code">@item.DisplayName</option>
+                            }
+                        </InputSelect>
+                        <div class="mud-input-outlined-border"></div>
+                    </div>
+                    <label class="mud-input-label mud-input-label-animated mud-input-label-outlined mud-input-label-inputcontrol" for="TenantId">@L["Language"]</label>
+                </div>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.LanguageCode" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
+            <div Class="d-flex justify-space-between align-center mb-1">
+                <label class="form-label">
+                    <InputCheckbox @bind-Value="Input.AgreeToTerms" class="form-check-input" />
+                    @L["I agree to the terms and privacy"]
+                </label>
+                <div class="mud-input-helper-text mud-input-error">
+                    <div class="d-flex">
+                        <ValidationMessage For="() => Input.AgreeToTerms" class="mud-input-error" />
+                    </div>
+                </div>
+            </div>
 
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
@@ -54,12 +196,8 @@
 </div>
 
 @code {
-    UserManager<ApplicationUser> UserManager;
-    IUserStore<ApplicationUser> UserStore;
-    SignInManager<ApplicationUser> SignInManager;
 
-
-    public const string PageUrl = "/pages/register";
+    public const string PageUrl = "/pages/authentication/register";
     private string Title = "Sign Up";
 
     [SupplyParameterFromQuery] private string? ReturnUrl { get; set; }
@@ -67,23 +205,18 @@
 
 
     [SupplyParameterFromForm] private InputModel Input { get; set; } = new();
-    private void InitializeServices()
-    {
-        UserStore = ScopedServices.GetRequiredService<IUserStore<ApplicationUser>>();
-        UserManager = ScopedServices.GetRequiredService<UserManager<ApplicationUser>>();
-        SignInManager = ScopedServices.GetRequiredService<SignInManager<ApplicationUser>>();
-    }
+
     protected override void OnInitialized()
     {
         Title = L["Sign Up"];
-        InitializeServices();
+
 
     }
 
     public async Task RegisterUser(EditContext editContext)
     {
         var user = CreateUser();
-        user.TenantId = Input.Tenant.Id;
+        user.TenantId = Input.TenantId;
         user.LanguageCode = Input.LanguageCode;
         user.TimeZoneId = Input.TimeZoneId;
         await UserStore.SetUserNameAsync(user, Input.UserName, CancellationToken.None);
@@ -92,14 +225,14 @@
         var result = await UserManager.CreateAsync(user, Input.Password);
         if (!result.Succeeded)
         {
-            message = string.Join(" ", result.Errors.Select(error => error.Description));
+            message = string.Join(", ", result.Errors.Select(error => error.Description));
             return;
         }
 
         result = await UserManager.AddToRoleAsync(user, RoleName.Basic);
         if (!result.Succeeded)
         {
-            message = string.Join(" ", result.Errors.Select(error => error.Description));
+            message = string.Join(", ", result.Errors.Select(error => error.Description));
             return;
         }
 
@@ -107,7 +240,7 @@
         Logger.LogInformation("New user account created. Username: {UserName}, User ID: {UserId}, Tenant ID: {TenantId}, Assigned Role: {RoleName}.",
             Input.UserName,
             userId,
-            Input.Tenant.Id,
+            Input.TenantId,
             RoleName.Basic);
         if (UserManager.Options.SignIn.RequireConfirmedEmail)
         {
@@ -117,11 +250,20 @@
                 Navigation.ToAbsoluteUri(ConfirmEmail.PageUrl).AbsoluteUri,
                 new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code, ["returnUrl"] = "/" });
             await Mediator.Publish(new UserActivationNotification(callbackUrl, Input.Email, userId, Input.UserName));
-            Navigation.NavigateTo(RegisterConfirmation.PageUrl);
+            RedirectManager.RedirectTo(RegisterConfirmation.PageUrl, new Dictionary<string, object?> { ["email"] = Input.Email });
         }
-        
-        await SignInManager.SignInAsync(user, true);
-        Navigation.NavigateTo(ReturnUrl??"/");
+        else if (UserManager.Options.SignIn.RequireConfirmedAccount)
+        {
+            var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
+            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+            var callbackUrl = Navigation.GetUriWithQueryParameters(
+                Navigation.ToAbsoluteUri(ConfirmEmail.PageUrl).AbsoluteUri,
+                new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
+            RedirectManager.RedirectTo(RegisterConfirmation.PageUrl, new Dictionary<string, object?> { ["email"] = Input.Email, ["EmailConfirmationLink"] = callbackUrl });
+        }
+
+        await SignInManager.SignInAsync(user, false);
+        RedirectManager.RedirectTo(ReturnUrl);
     }
 
     private ApplicationUser CreateUser()
@@ -172,13 +314,13 @@
         [Range(typeof(bool), "true", "true", ErrorMessage = "You must agree to the terms.")]
         public bool AgreeToTerms { get; set; } = true;
 
+        [Required]
+        [Display(Name = "Tenant Id")]
+        public string TenantId { get; set; } = "";
         [Display(Name = "Time Zone")]
         public string? TimeZoneId { get; set; } = TimeZoneInfo.Local.Id;
         [Display(Name = "Language")]
         public string? LanguageCode { get; set; } = CultureInfo.CurrentCulture.Name;
-        [Required]
-        [Display(Name = "Tenant")]
-        public TenantDto? Tenant { get; set; }
     }
 
 }

--- a/src/Server.UI/Pages/Identity/Authentication/RegisterConfirmation.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/RegisterConfirmation.razor
@@ -1,15 +1,51 @@
-﻿@page "/pages/registerConfirmation"
+﻿@page "/pages/authentication/RegisterConfirmation"
 @using CleanArchitecture.Blazor.Domain.Identity
 
+
+@inject UserManager<ApplicationUser> UserManager
+@inject IdentityRedirectManager RedirectManager
 @inject IStringLocalizer<RegisterConfirmation> L
 <PageTitle>@L["Register confirmation"]</PageTitle>
 
-<MudText Typo="Typo.h4" GutterBottom="true">@L["Register confirmation"]</MudText>
+<h1>@L["Register confirmation"]</h1>
 
+<StatusMessage Message="@statusMessage" Error="true"/>
 
-<MudText Typo="Typo.body1">@L["Please check your email to confirm your account."]</MudText>
-
+@if (EmailConfirmationLink is not null)
+{
+    <p>
+        L["This app does not currently have a real email sender registered, see"] <a href="https://aka.ms/aspaccountconf">@L["these docs"]</a> @L["how to configure a real email sender. Normally this would be emailed:"] <a class="mud-button-root mud-button mud-button-text mud-button-text-default mud-button-text-size-medium mud-ripple" href="@EmailConfirmationLink">@L["here to confirm your account"]</a>
+    </p>
+}
+else
+{
+    <MudText Typo="Typo.body1">@L["Please check your email to confirm your account."]</MudText>
+}
 
 @code {
-    public const string PageUrl = "/pages/registerConfirmation";
+    public const string PageUrl = "/pages/authentication/RegisterConfirmation";
+    [SupplyParameterFromQuery] private string? EmailConfirmationLink { get; set; }
+    private string? statusMessage;
+
+    [CascadingParameter] private HttpContext HttpContext { get; set; } = default!;
+
+    [SupplyParameterFromQuery] private string? Email { get; set; }
+
+    [SupplyParameterFromQuery] private string? ReturnUrl { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Email is null)
+        {
+            RedirectManager.RedirectTo("/");
+        }
+
+        var user = await UserManager.FindByEmailAsync(Email);
+        if (user is null)
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            statusMessage = L["Error finding user for unspecified email"];
+        }
+    }
+
 }

--- a/src/Server.UI/Pages/Identity/Authentication/RegisterConfirmation.razor
+++ b/src/Server.UI/Pages/Identity/Authentication/RegisterConfirmation.razor
@@ -1,51 +1,15 @@
-﻿@page "/pages/authentication/RegisterConfirmation"
+﻿@page "/pages/registerConfirmation"
 @using CleanArchitecture.Blazor.Domain.Identity
 
-
-@inject UserManager<ApplicationUser> UserManager
-@inject IdentityRedirectManager RedirectManager
 @inject IStringLocalizer<RegisterConfirmation> L
 <PageTitle>@L["Register confirmation"]</PageTitle>
 
-<h1>@L["Register confirmation"]</h1>
+<MudText Typo="Typo.h4" GutterBottom="true">@L["Register confirmation"]</MudText>
 
-<StatusMessage Message="@statusMessage" Error="true"/>
 
-@if (EmailConfirmationLink is not null)
-{
-    <p>
-        L["This app does not currently have a real email sender registered, see"] <a href="https://aka.ms/aspaccountconf">@L["these docs"]</a> @L["how to configure a real email sender. Normally this would be emailed:"] <a class="mud-button-root mud-button mud-button-text mud-button-text-default mud-button-text-size-medium mud-ripple" href="@EmailConfirmationLink">@L["here to confirm your account"]</a>
-    </p>
-}
-else
-{
-    <MudText Typo="Typo.body1">@L["Please check your email to confirm your account."]</MudText>
-}
+<MudText Typo="Typo.body1">@L["Please check your email to confirm your account."]</MudText>
+
 
 @code {
-    public const string PageUrl = "/pages/authentication/RegisterConfirmation";
-    [SupplyParameterFromQuery] private string? EmailConfirmationLink { get; set; }
-    private string? statusMessage;
-
-    [CascadingParameter] private HttpContext HttpContext { get; set; } = default!;
-
-    [SupplyParameterFromQuery] private string? Email { get; set; }
-
-    [SupplyParameterFromQuery] private string? ReturnUrl { get; set; }
-
-    protected override async Task OnInitializedAsync()
-    {
-        if (Email is null)
-        {
-            RedirectManager.RedirectTo("");
-        }
-
-        var user = await UserManager.FindByEmailAsync(Email);
-        if (user is null)
-        {
-            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-            statusMessage = L["Error finding user for unspecified email"];
-        }
-    }
-
+    public const string PageUrl = "/pages/registerConfirmation";
 }

--- a/src/Server.UI/Pages/Identity/Users/Components/UserForm.razor
+++ b/src/Server.UI/Pages/Identity/Users/Components/UserForm.razor
@@ -47,7 +47,7 @@
         <MudItem sm="6" xs="12">
             <MultiTenantAutocomplete For="@(() => Model.Tenant)"
                                      T="TenantDto"
-                                     Label="@L["Select Tenant"]"
+                                     Label="@L["Tenant"]"
                                      Required="true"
                                      ValueChanged="@(x=>TenantChanged(x))"
                                      Value="@Model.Tenant">
@@ -55,24 +55,28 @@
             </MultiTenantAutocomplete>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.Provider)" @bind-Value="Model.Provider" Label="@L["Provider"]" Variant="Variant.Text"></MudTextField>
+            <MudTextField For="@(() => Model.Provider)" @bind-Value="Model.Provider" Label="@L["Provider"]" Variant="Variant.Text" ReadOnly></MudTextField>
         </MudItem>
 
         <MudItem xs="12" sm="6">
             <MudTextField For="@(() => Model.UserName)" @bind-Value="Model.UserName" Label="@L["User Name"]" Variant="Variant.Text" Required="true"></MudTextField>
         </MudItem>
         <MudItem xs="12" sm="6">
+            <div class="d-fex">
+                <MudCheckBox For="@(() => Model.IsActive)" @bind-Value="Model.IsActive" Label="@L["Is Active"]"></MudCheckBox>
+            </div>
+        </MudItem>
+        <MudItem xs="12" sm="6">
+            <MudTextField For="@(() => Model.DisplayName)" @bind-Value="Model.DisplayName" Label="@L["Full Name"]" Variant="Variant.Text"></MudTextField>
+        </MudItem>
+        <MudItem xs="12" sm="6">
             <PickSuperiorIdAutocomplete For="@(() => Model.Superior)" T="ApplicationUserDto"
                                         OwnerName="@Model.UserName"
                                         Clearable="true"
                                         TenantId="@Model.Tenant?.Id"
-                                        Label="@L["Select Superior"]"
+                                        Label="@L["Superior"]"
                                         @bind-Value="@Model.Superior">
             </PickSuperiorIdAutocomplete>
-
-        </MudItem>
-        <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.DisplayName)" @bind-Value="Model.DisplayName" Label="@L["Full Name"]" Variant="Variant.Text"></MudTextField>
         </MudItem>
         <MudItem xs="12" sm="6">
             <MudTextField For="@(() => Model.Email)" @bind-Value="Model.Email" Label="@L["E-mail"]" Variant="Variant.Text" Required="true"></MudTextField>
@@ -80,14 +84,14 @@
         <MudItem xs="12" sm="6">
             <MudTextField For="@(() => Model.PhoneNumber)" @bind-Value="Model.PhoneNumber" Label="@L["Phone Number"]" Variant="Variant.Text"></MudTextField>
         </MudItem>
-
-
-        <MudItem xs="12" sm="6">
-            <MudText Typo="Typo.caption">@L["Status"]</MudText>
-            <div class="d-fex">
-                <MudCheckBox For="@(() => Model.IsActive)" @bind-Value="Model.IsActive" Label="@L["Is Active"]"></MudCheckBox>
-            </div>
+        <MudItem sm="6" xs="12">
+            <TimeZoneAutocomplete T="string" For="@(() => Model.TimeZoneId)" ShrinkLabel="true" @bind-Value="Model.TimeZoneId" Label="@L["Time Zone"]" Variant="Variant.Text"></TimeZoneAutocomplete>
         </MudItem>
+        <MudItem sm="6" xs="12">
+            <LanguageAutocomplete T="string" For="@(() => Model.LanguageCode)" ShrinkLabel="true" @bind-Value="Model.LanguageCode" Label="@L["Language"]" Variant="Variant.Text"></LanguageAutocomplete>
+        </MudItem>
+
+
         <MudItem xs="12" sm="12">
             <MudText Typo="Typo.caption">@L["Assign Roles"]</MudText>
             <MudGrid Class="mt-1" Spacing="2">

--- a/src/Server.UI/Pages/Identity/Users/Profile.razor
+++ b/src/Server.UI/Pages/Identity/Users/Profile.razor
@@ -250,7 +250,7 @@ else
                 user.ProfilePictureDataUrl = model.ProfilePictureDataUrl;
                 await UserManager.UpdateAsync(user);
                 Snackbar.Add(L["The avatar has been updated"], Severity.Info);
-                UserProfileStateService.UpdateUserProfile(user.UserName,user.ProfilePictureDataUrl, user.DisplayName, user.PhoneNumber);
+                UserProfileStateService.UpdateUserProfile(user.UserName,user.ProfilePictureDataUrl, user.DisplayName, user.PhoneNumber,user.TimeZoneId, user.LanguageCode);
                 await OnlineUserTracker.Update(user.Id,
                                                user.UserName??"",
                                                user.DisplayName ?? "",
@@ -275,7 +275,7 @@ else
                 user.LanguageCode = model.LanguageCode;
                 user.ProfilePictureDataUrl = model.ProfilePictureDataUrl;
                 await UserManager.UpdateAsync(user);
-                UserProfileStateService.UpdateUserProfile(user.UserName,user.ProfilePictureDataUrl, user.DisplayName, user.PhoneNumber);
+                UserProfileStateService.UpdateUserProfile(user.UserName,user.ProfilePictureDataUrl, user.DisplayName, user.PhoneNumber,user.TimeZoneId, user.LanguageCode);
                 await OnlineUserTracker.Update(user.Id,
                                                user.UserName ?? "",
                                                user.DisplayName ?? "",

--- a/src/Server.UI/Pages/Identity/Users/Profile.razor
+++ b/src/Server.UI/Pages/Identity/Users/Profile.razor
@@ -85,6 +85,12 @@ else
                     <MudItem sm="6" xs="12">
                         <MudTextField For="@(() => model.PhoneNumber)" ShrinkLabel="true" @bind-Value="model.PhoneNumber" Label="@L["Phone Number"]" Variant="Variant.Text"></MudTextField>
                     </MudItem>
+                    <MudItem sm="6" xs="12">
+                        <TimeZoneAutocomplete T="string" For="@(() => model.TimeZoneId)" ShrinkLabel="true" @bind-Value="model.TimeZoneId" Label="@L["Time Zone"]" Variant="Variant.Text"></TimeZoneAutocomplete>
+                    </MudItem>
+                    <MudItem sm="6" xs="12">
+                        <LanguageAutocomplete T="string" For="@(() => model.LanguageCode)" ShrinkLabel="true" @bind-Value="model.LanguageCode" Label="@L["Language"]" Variant="Variant.Text"></LanguageAutocomplete>
+                    </MudItem>
                     <MudItem sm="12" xs="12" Class="d-flex justify-end">
                         <MudButton ButtonType="ButtonType.Button" Disabled="@_submitting" Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto" OnClick="@(async () => await Submit())">
                             @if (_submitting)
@@ -265,6 +271,8 @@ else
                 var user = await UserManager.FindByNameAsync(_currentUserName) ?? throw new NotFoundException($"The application user [{_currentUserName}] was not found.");
                 user.PhoneNumber = model.PhoneNumber;
                 user.DisplayName = model.DisplayName;
+                user.TimeZoneId = model.TimeZoneId;
+                user.LanguageCode = model.LanguageCode;
                 user.ProfilePictureDataUrl = model.ProfilePictureDataUrl;
                 await UserManager.UpdateAsync(user);
                 UserProfileStateService.UpdateUserProfile(user.UserName,user.ProfilePictureDataUrl, user.DisplayName, user.PhoneNumber);

--- a/src/Server.UI/Pages/Identity/Users/Users.razor
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor
@@ -16,6 +16,7 @@
 @using CleanArchitecture.Blazor.Infrastructure.Constants.Role
 @using CleanArchitecture.Blazor.Infrastructure.Constants.ClaimTypes
 @using System.Security.Claims
+@using System.Globalization
 @using ZiggyCreatures.Caching.Fusion
 
 @attribute [Authorize(Policy = Permissions.Users.View)]
@@ -456,7 +457,9 @@
                 SuperiorId = model.Superior?.Id,
                 ProfilePictureDataUrl = model.ProfilePictureDataUrl,
                 EmailConfirmed = false,
-                IsActive = model.IsActive
+                IsActive = model.IsActive,
+                LanguageCode = model.LanguageCode,
+                TimeZoneId = model.TimeZoneId
             };
 
         var identityResult = await UserManager.CreateAsync(applicationUser);
@@ -485,6 +488,8 @@
         user.IsActive = item.IsActive;
         user.TenantId = item.TenantId;
         user.SuperiorId = item.SuperiorId;
+        user.LanguageCode = item.LanguageCode;
+        user.TimeZoneId = item.TimeZoneId;
         var identityResult = await UserManager.UpdateAsync(user);
         if (identityResult.Succeeded)
         {
@@ -523,11 +528,17 @@
             await UserManager.AddToRoleAsync(user, RoleName.Basic);
         }
     }
-
-
     private async Task OnCreate()
     {
-        var model = new ApplicationUserDto { Provider = "Local", Email = "", UserName = "", AssignedRoles = new[] { RoleName.Basic } };
+        var model = new ApplicationUserDto
+            {
+                Provider = "Local",
+                Email = "",
+                UserName = "",
+                AssignedRoles = new[] { RoleName.Basic },
+                TimeZoneId = TimeZoneInfo.Local.Id,
+                LanguageCode = CultureInfo.CurrentCulture.Name
+            };
         await ShowCreateUserDialog(model, L["Create a new user"]);
     }
 
@@ -859,7 +870,7 @@
     {
         return await ExcelService.ExportAsync(items,
             new Dictionary<string, Func<ApplicationUserDto, object?>>
-                                            {
+                                                {
                 { L["Id"], item => item.Id },
                 { L["User Name"], item => item.UserName },
                 { L["Full Name"], item => item.DisplayName },
@@ -867,7 +878,7 @@
                 { L["Phone Number"], item => item.PhoneNumber },
                 { L["Tenant Id"], item => item.TenantId },
                 { L["Superior Id"], item => item.SuperiorId }
-                                            }, L["Users"]);
+                                                }, L["Users"]);
     }
 
     private async Task OnImportData(IBrowserFile file)

--- a/src/Server.UI/Pages/Products/Products.razor
+++ b/src/Server.UI/Pages/Products/Products.razor
@@ -236,8 +236,6 @@
 
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
     [CascadingParameter] private UserProfile? UserProfile { get; set; }
-    [CascadingParameter(Name = "LocalTimezoneOffset")]
-    private TimeSpan _localTimezoneOffset { get; set; }
     public string? Title { get; private set; }
     private HashSet<ProductDto> _selectedItems = new();
     private MudDataGrid<ProductDto> _table = default!;
@@ -280,7 +278,6 @@
             Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
-            Query.LocalTimezoneOffset = _localTimezoneOffset;
             var result = await Mediator.Send(Query).ConfigureAwait(false);
 
             return new GridData<ProductDto> { TotalItems = result.TotalItems, Items = result.Items };

--- a/src/Server.UI/Pages/SystemManagement/AuditTrails.razor
+++ b/src/Server.UI/Pages/SystemManagement/AuditTrails.razor
@@ -125,22 +125,17 @@
 
 @code
 {
-  
-    private int _timezoneOffset;
     public string Title { get; private set; } = "Audit Trails";
     private MudDataGrid<AuditTrailDto> _table = null!;
     private bool _loading;
     private int _defaultPageSize = 15;
-
     private readonly AuditTrailDto _currentDto = new();
-
     private AuditTrailsWithPaginationQuery Query { get; } = new();
     [CascadingParameter] private UserProfile? UserProfile { get; set; }
-    [CascadingParameter(Name = "LocalTimezoneOffset")]
-    private TimeSpan _localTimezoneOffset { get; set; }
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
         Title = L[_currentDto.GetClassDescription()];
+        return Task.CompletedTask;
     }
 
     private async Task<GridData<AuditTrailDto>> ServerReload(GridState<AuditTrailDto> state)
@@ -153,7 +148,7 @@
             Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
-            Query.LocalTimezoneOffset = _localTimezoneOffset;
+
             var result = await Mediator.Send(Query).ConfigureAwait(false);
             return new GridData<AuditTrailDto> { TotalItems = result.TotalItems, Items = result.Items };
         }

--- a/src/Server.UI/Pages/SystemManagement/Logs.razor
+++ b/src/Server.UI/Pages/SystemManagement/Logs.razor
@@ -157,14 +157,13 @@
 @code
 {
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
+    [CascadingParameter] private UserProfile? UserProfile { get; set; }
     private string Title { get; set; } = "Logs";
     private string _searchString = string.Empty;
     private MudDataGrid<LogDto> _table = default!;
     private readonly LogDto _currentDto = new();
     private readonly int _defaultPageSize = 15;
-    [CascadingParameter(Name = "LocalTimezoneOffset")]
-    private TimeSpan _localTimezoneOffset { get; set; }
-
+    private TimeSpan _localTimeOffset => UserProfile?.LocalTimeOffset ?? TimeSpan.Zero;
     private bool _loading;
     private bool _clearing;
     private bool _canPurge;
@@ -188,7 +187,7 @@
             Query.SortDirection = state.SortDefinitions.FirstOrDefault()?.Descending ?? true ? SortDirection.Descending.ToString() : SortDirection.Ascending.ToString();
             Query.PageNumber = state.Page + 1;
             Query.PageSize = state.PageSize;
-            Query.LocalTimezoneOffset = _localTimezoneOffset;
+            Query.LocalTimeOffset = _localTimeOffset;
             var result = await Mediator.Send(Query).ConfigureAwait(false);
 
             return new GridData<LogDto> { TotalItems = result.TotalItems, Items = result.Items };

--- a/src/Server.UI/Pages/Tenants/Tenants.razor
+++ b/src/Server.UI/Pages/Tenants/Tenants.razor
@@ -157,7 +157,6 @@
 @code
 {
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
-
     public string? Title { get; private set; }
     private int _defaultPageSize = 15;
     private HashSet<TenantDto> _selectedItems = new();

--- a/src/Server.UI/Program.cs
+++ b/src/Server.UI/Program.cs
@@ -2,6 +2,7 @@
 using CleanArchitecture.Blazor.Infrastructure;
 using CleanArchitecture.Blazor.Server.UI;
 
+
 var builder = WebApplication.CreateBuilder(args);
 builder.RegisterSerilog();
 builder.WebHost.UseStaticWebAssets();

--- a/src/Server.UI/Services/JsInterop/LocalTimezoneOffset.cs
+++ b/src/Server.UI/Services/JsInterop/LocalTimezoneOffset.cs
@@ -2,11 +2,11 @@
 
 namespace CleanArchitecture.Blazor.Server.UI.Services.JsInterop;
 
-public class LocalTimezoneOffset
+public class LocalTimeOffset
 {
     private readonly IJSRuntime _jsRuntime;
 
-    public LocalTimezoneOffset(IJSRuntime jsRuntime)
+    public LocalTimeOffset(IJSRuntime jsRuntime)
     {
         _jsRuntime = jsRuntime;
     }

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -3,8 +3,8 @@
   "DatabaseSettings": {
     //"DBProvider": "sqlite",
     //"ConnectionString": "Data Source=BlazorDashboardDb.db"
-    "DBProvider": "mssql",
-    "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=BlazorDashboardDb;Trusted_Connection=True;MultipleActiveResultSets=true;"
+    //"DBProvider": "mssql",
+    //"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=BlazorDashboardDb;Trusted_Connection=True;MultipleActiveResultSets=true;"
     //"DBProvider": "postgresql",
     //"ConnectionString": "Server=127.0.0.1;Database=BlazorDashboardDb;User Id=root;Password=root;Port=5432"
   },

--- a/src/Server.UI/appsettings.json
+++ b/src/Server.UI/appsettings.json
@@ -3,8 +3,8 @@
   "DatabaseSettings": {
     //"DBProvider": "sqlite",
     //"ConnectionString": "Data Source=BlazorDashboardDb.db"
-    //"DBProvider": "mssql",
-    //"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=BlazorDashboardDb;Trusted_Connection=True;MultipleActiveResultSets=true;"
+    "DBProvider": "mssql",
+    "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=BlazorDashboardDb;Trusted_Connection=True;MultipleActiveResultSets=true;"
     //"DBProvider": "postgresql",
     //"ConnectionString": "Server=127.0.0.1;Database=BlazorDashboardDb;User Id=root;Password=root;Port=5432"
   },


### PR DESCRIPTION
This PR introduces two new custom MudAutocomplete components, TimeZoneAutocomplete and LanguageAutocomplete, to enhance user experience by allowing easy selection of time zones and languages. Additionally, the ApplicationUser class has been extended to store the selected time zone and language for each user.
![image](https://github.com/user-attachments/assets/dd40e058-1c22-487d-9995-fe149440f9b7)
![image](https://github.com/user-attachments/assets/887b49c2-15f3-4a65-aa40-3813579bf9c6)

