### PR TITLE
Refactor User Tracking and Add Session Cleanup Handler

### DIFF
--- a/src/Server.UI/Components/Breadcrumbs/Breadcrumbs.razor
+++ b/src/Server.UI/Components/Breadcrumbs/Breadcrumbs.razor
@@ -8,11 +8,11 @@
 
         @if (OnSaveButtonClick.HasDelegate)
         {
-            <MudLoadingButton StartIcon="@Icons.Material.Filled.Save" Color="Color.Primary" DropShadow="false" Loading="@Saving" Variant="Variant.Outlined" OnClick="@Save">@ConstantString.Save</MudLoadingButton>
+            <MudLoadingButton StartIcon="@Icons.Material.Filled.Save" Color="Color.Primary" DropShadow="false" Loading="@Saving"  OnClick="@Save">@ConstantString.Save</MudLoadingButton>
         }
         @if (OnGoEditClick.HasDelegate)
         {
-            <MudButton StartIcon="@Icons.Material.Filled.Edit" Color="Color.Primary" Variant="Variant.Outlined" OnClick="@GoEdit">@ConstantString.Edit</MudButton>
+            <MudButton StartIcon="@Icons.Material.Filled.Edit" Color="Color.Primary" OnClick="@GoEdit">@ConstantString.Edit</MudButton>
         }
         @if (OnDeleteClick.HasDelegate || OnPrintClick.HasDelegate)
         {

--- a/src/Server.UI/Components/Dialogs/ConfirmationDialog.razor
+++ b/src/Server.UI/Components/Dialogs/ConfirmationDialog.razor
@@ -5,8 +5,8 @@
         <MudText>@ContentText</MudText>
     </DialogContent>
     <DialogActions>
-        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel">@ConstantString.Cancel</MudButton>
-        <MudButton StartIcon="@Icons.Material.Filled.Delete" Color="Color.Error" Variant="Variant.Filled" title="@ConstantString.Confirm" OnClick="Submit">@ConstantString.Confirm</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel" title="@ConstantString.Cancel">@ConstantString.Cancel</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.Delete" Color="Color.Error" title="@ConstantString.Confirm" OnClick="Submit">@ConstantString.Confirm</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/src/Server.UI/Components/Dialogs/DeleteConfirmation.razor
+++ b/src/Server.UI/Components/Dialogs/DeleteConfirmation.razor
@@ -11,8 +11,8 @@
         <MudText>@ContentText</MudText>
     </DialogContent>
     <DialogActions>
-        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel">@ConstantString.Cancel</MudButton>
-        <MudButton StartIcon="@Icons.Material.Outlined.Delete" Color="Color.Error" Variant="Variant.Filled" title="@ConstantString.Delete" OnClick="Submit">@ConstantString.Confirm</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel" title="@ConstantString.Cancel">@ConstantString.Cancel</MudButton>
+        <MudButton StartIcon="@Icons.Material.Outlined.Delete" Color="Color.Error"  title="@ConstantString.Delete" OnClick="Submit">@ConstantString.Confirm</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/src/Server.UI/Components/Dialogs/LogoutConfirmation.razor
+++ b/src/Server.UI/Components/Dialogs/LogoutConfirmation.razor
@@ -9,8 +9,8 @@
         <MudText>@ContentText</MudText>
     </DialogContent>
     <DialogActions>
-        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel">@ConstantString.Cancel</MudButton>
-        <MudButton StartIcon="@Icons.Material.Filled.Logout" Color="@Color" Variant="Variant.Filled" OnClick="Submit">@ConstantString.Logout</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="Cancel" title="@ConstantString.Cancel">@ConstantString.Cancel</MudButton>
+        <MudButton StartIcon="@Icons.Material.Filled.Logout" Color="@Color" title="@ConstantString.Logout" OnClick="Submit">@ConstantString.Logout</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/src/Server.UI/Components/Fusion/ActiveUserSession.razor
+++ b/src/Server.UI/Components/Fusion/ActiveUserSession.razor
@@ -6,16 +6,16 @@
 @inject IUserSessionTracker UserSessionTracker
 @inject IStringLocalizer<ActiveUserSession> L
 
-@if (!string.IsNullOrEmpty(userName) && State.Value.Any())
+@if (!string.IsNullOrEmpty(currentUserId) && State.Value.Any())
 {
-    <MudAlert Class="mb-2" Severity="MudBlazor.Severity.Error" Variant="Variant.Filled" Dense="true">@Message</MudAlert>
+    <MudAlert Class="mb-2" Severity="MudBlazor.Severity.Error" Variant="Variant.Outlined" Dense="true">@Message</MudAlert>
 }
 
 @code {
     [Parameter]
     public string PageComponent { get; set; } = nameof(ActiveUserSession);
     private string Message => $"{string.Join(", ", State.Value)} {L["has this dialog open."]}";
-    private string? userName;
+    private string? currentUserId;
     [CascadingParameter]
     private Task<AuthenticationState> AuthState { get; set; } = default!;
     [Inject] private UIActionTracker UIActionTracker { get; init; } = null!;
@@ -23,8 +23,10 @@
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthState;
-        userName = authState.User.GetDisplayName() ?? (authState.User.GetUserName()??string.Empty);
-        await UserSessionTracker.AddUserSession(PageComponent ?? nameof(ActiveUserSession), userName);
+        currentUserId = authState.User.GetUserId() ?? string.Empty;
+        await UserSessionTracker.AddUserSession(PageComponent ?? nameof(ActiveUserSession));
+
+
     }
 
     protected override ComputedState<string[]>.Options GetStateOptions()
@@ -32,11 +34,11 @@
 
     protected override async Task<string[]> ComputeState(CancellationToken cancellationToken)
     {
-        var result = await UserSessionTracker.GetUserSessions(cancellationToken);
+        var result = await UserSessionTracker.GetUserSessions(PageComponent,cancellationToken);
         if (result.Any())
         {
 
-            return result.Where(x => x.PageComponent == PageComponent).Where(x => x.UserSessions.Any(y => y != userName)).SelectMany(x => x.UserSessions.Where(y => y != userName)).ToArray();
+            return result.Where(x => x.UserId!=currentUserId).Select(x=>x.DisplayName??x.UserName).ToArray();
         }
 
         return Array.Empty<string>();
@@ -44,7 +46,7 @@
 
     public override async ValueTask DisposeAsync()
     {
-        await UserSessionTracker.RemoveUserSession(PageComponent, userName??string.Empty);
+        await UserSessionTracker.RemoveUserSession(PageComponent);
         GC.Collect();
     }
 }

--- a/src/Server.UI/Components/Fusion/OnlineUsersTracker.razor
+++ b/src/Server.UI/Components/Fusion/OnlineUsersTracker.razor
@@ -3,25 +3,25 @@
 @using ActualLab.Fusion.Blazor
 @using ActualLab.Fusion.UI
 
-@inherits ComputedStateComponent<UserInfo[]>
+@inherits ComputedStateComponent<List<SessionInfo>>
 @inject IOnlineUserTracker OnlineUserTracker
 @inject IStringLocalizer<ActiveUserSession> L
 @inject UserProfileStateService UserProfileStateService
 @if (State.HasValue && State.LastNonErrorValue.Any())
 {
     <div class="d-flex flex-row gap-2 my-3 gap-2 my-3">
-        @foreach (var user in State.LastNonErrorValue.OrderBy(u => u.Name != currentUserName))
+        @foreach (var user in State.LastNonErrorValue.OrderBy(u => u.UserId != currentUserId))
         {
             <MudBadge Color="Color.Success" Overlap="false" Dot="true" Bordered="true">
                 @if (string.IsNullOrEmpty(user.ProfilePictureDataUrl))
                 {
-                    <MudAvatar title="@user.Name">
-                        @user.Name.First()
+                    <MudAvatar title="@user.UserName">
+                        @user.UserName.First()
                     </MudAvatar>
                 }
                 else
                 {
-                    <MudAvatar title="@user.Name">
+                    <MudAvatar title="@user.UserName">
                         <MudImage Src="@user.ProfilePictureDataUrl"></MudImage>
                     </MudAvatar>
                 }
@@ -38,7 +38,7 @@
 @code {
 
     private string sessionId = Guid.NewGuid().ToString();
-    private string? currentUserName;
+    private string? currentUserId;
     [CascadingParameter] private Task<AuthenticationState> AuthState { get; set; } = default!;
     [Inject] private UIActionTracker UIActionTracker { get; init; } = null!;
     private TimeSpan UpdateDelay { get; set; } = TimeSpan.FromSeconds(5);
@@ -49,33 +49,28 @@
         {
             await UserProfileStateService.InitializeAsync(state.User.Identity.Name);
             var userProfile = UserProfileStateService.UserProfile;
-            currentUserName = userProfile.UserName;
-            await OnlineUserTracker.Add(sessionId, new UserInfo(userProfile.UserId,
+            currentUserId = userProfile.UserId;
+            await OnlineUserTracker.Initial(new SessionInfo(userProfile.UserId,
                 userProfile.UserName,
-                userProfile.Email,
                 userProfile.DisplayName ?? string.Empty,
+                "",
+                userProfile.TenantId,
                 userProfile.ProfilePictureDataUrl ?? string.Empty,
-                userProfile.SuperiorName ?? string.Empty,
-                userProfile.SuperiorId ?? string.Empty,
-                userProfile.TenantId ?? string.Empty,
-                userProfile.TenantName ?? string.Empty,
-                userProfile.PhoneNumber,
-                userProfile.AssignedRoles ?? Array.Empty<string>(),
                 UserPresence.Available));
         }
     }
 
-    protected override ComputedState<UserInfo[]>.Options GetStateOptions()
+    protected override ComputedState<List<SessionInfo>>.Options GetStateOptions()
      => new() { UpdateDelayer = new UpdateDelayer(UIActionTracker, UpdateDelay) };
 
-    protected override Task<UserInfo[]> ComputeState(CancellationToken cancellationToken)
+    protected override Task<List<SessionInfo>> ComputeState(CancellationToken cancellationToken)
     {
         return OnlineUserTracker.GetOnlineUsers(cancellationToken);
     }
 
     public override async ValueTask DisposeAsync()
     {
-        await OnlineUserTracker.Remove(sessionId);
+        await OnlineUserTracker.Logout();
         GC.Collect();
     }
 }

--- a/src/Server.UI/Components/Routes.razor
+++ b/src/Server.UI/Components/Routes.razor
@@ -16,7 +16,7 @@
                         <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Error" Size="Size.Large" Class="mb-4" />
                         <MudText Typo="Typo.h5">@L["You are not authorized to view this page."]</MudText>
                         <MudText Typo="Typo.body1" Class="mt-2">@L["If you need access to this page, please contact the administrator."]</MudText>
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="mt-4">@L["Contact Administrator"]</MudButton>
+                        <MudButton Color="Color.Primary" Class="mt-4">@L["Contact Administrator"]</MudButton>
                     </MudPaper>
                 </NotAuthorized>
             </AuthorizeRouteView>

--- a/src/Server.UI/Components/Shared/CustomError.razor
+++ b/src/Server.UI/Components/Shared/CustomError.razor
@@ -24,7 +24,7 @@
         </div>
     </DialogContent>
     <DialogActions>
-        <MudButton Variant="Variant.Outlined" Color="Color.Default" OnClick="OnRefresh">@ConstantString.Refresh</MudButton>
+        <MudButton Color="Color.Default" OnClick="OnRefresh">@ConstantString.Refresh</MudButton>
     </DialogActions>
 </MudDialog>
 

--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -19,6 +19,7 @@ using ActualLab.Fusion;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
 using CleanArchitecture.Blazor.Server.UI.Middlewares;
 using Polly;
+using Microsoft.AspNetCore.Components.Server.Circuits;
 
 
 namespace CleanArchitecture.Blazor.Server.UI;
@@ -68,7 +69,7 @@ public static class DependencyInjection
         var fusion = services.AddFusion();
         fusion.AddService<IUserSessionTracker, UserSessionTracker>();
         fusion.AddService<IOnlineUserTracker, OnlineUserTracker>();
-
+        services.AddScoped<CircuitHandler, UserSessionCircuitHandler>();
 
         services.AddScoped<LocalizationCookiesMiddleware>()
             .Configure<RequestLocalizationOptions>(options =>

--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -17,7 +17,6 @@ using QuestPDF;
 using QuestPDF.Infrastructure;
 using ActualLab.Fusion;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
-using ActualLab.Fusion.Extensions;
 using CleanArchitecture.Blazor.Server.UI.Middlewares;
 using Polly;
 
@@ -66,12 +65,9 @@ public static class DependencyInjection
         services.AddHotKeys2();
 
         // Fusion services
-        services.AddFusion(fusion =>
-        {
-            fusion.AddInMemoryKeyValueStore();
-            fusion.AddService<IUserSessionTracker, UserSessionTracker>();
-            fusion.AddService<IOnlineUserTracker, OnlineUserTracker>();
-        });
+        var fusion = services.AddFusion();
+        fusion.AddService<IUserSessionTracker, UserSessionTracker>();
+        fusion.AddService<IOnlineUserTracker, OnlineUserTracker>();
 
 
         services.AddScoped<LocalizationCookiesMiddleware>()
@@ -150,7 +146,6 @@ public static class DependencyInjection
 
         app.UseStatusCodePagesWithRedirects("/404");
         app.MapHealthChecks("/health");
-
         app.UseAuthentication();
         app.UseAuthorization();
         app.UseAntiforgery();

--- a/src/Server.UI/DependencyInjection.cs
+++ b/src/Server.UI/DependencyInjection.cs
@@ -44,6 +44,8 @@ public static class DependencyInjection
         services.AddMudServices(config =>
         {
             MudGlobal.InputDefaults.ShrinkLabel = true;
+            //MudGlobal.InputDefaults.Variant = Variant.Outlined;
+            //MudGlobal.ButtonDefaults.Variant = Variant.Outlined;
             config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomCenter;
             config.SnackbarConfiguration.NewestOnTop = false;
             config.SnackbarConfiguration.ShowCloseIcon = true;

--- a/src/Server.UI/Hubs/HubClient.cs
+++ b/src/Server.UI/Hubs/HubClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using CleanArchitecture.Blazor.Infrastructure.Constants.User;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 
@@ -35,7 +36,8 @@ public sealed class HubClient : IAsyncDisposable
                 options.Cookies = container;
             }).WithAutomaticReconnect().Build();
 
-        _hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
+        _hubConnection.ServerTimeout = TimeSpan.FromSeconds(20);
+        _hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(10);
 
         // Observe and await the async result of the event invocation
         _hubConnection.On<string, string>(nameof(ISignalRHub.Connect), OnLoginEventAsync);
@@ -52,6 +54,8 @@ public sealed class HubClient : IAsyncDisposable
 
         _hubConnection.On<string, string, string>(nameof(ISignalRHub.SendPrivateMessage),
             async (from, to, message) => await OnMessageReceivedEventAsync(from, message).ConfigureAwait(false));
+
+   
     }
 
     // Handle the result of async event invocations
@@ -102,7 +106,7 @@ public sealed class HubClient : IAsyncDisposable
             await Task.Run(() => MessageReceivedEvent?.Invoke(this, new MessageReceivedEventArgs(from, message))).ConfigureAwait(false);
         }
     }
-
+    
     public async ValueTask DisposeAsync()
     {
         try
@@ -114,7 +118,7 @@ public sealed class HubClient : IAsyncDisposable
             await _hubConnection.DisposeAsync().ConfigureAwait(false);
         }
     }
-
+    
     // Event handlers
     public event EventHandler<UserStateChangeEventArgs>? LoginEvent;
     public event EventHandler<UserStateChangeEventArgs>? LogoutEvent;

--- a/src/Server.UI/Middlewares/UserSessionCircuitHandler.cs
+++ b/src/Server.UI/Middlewares/UserSessionCircuitHandler.cs
@@ -1,0 +1,38 @@
+﻿using CleanArchitecture.Blazor.Server.UI.Services.Fusion;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+
+namespace CleanArchitecture.Blazor.Server.UI.Middlewares;
+
+public class UserSessionCircuitHandler : CircuitHandler
+{
+    private readonly IUserSessionTracker _userSessionTracker;
+    private readonly IOnlineUserTracker _onlineUserTracker;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+
+    public UserSessionCircuitHandler(IUserSessionTracker userSessionTracker, IOnlineUserTracker OnlineUserTracker, IHttpContextAccessor httpContextAccessor)
+    {
+        _userSessionTracker = userSessionTracker;
+        _onlineUserTracker = OnlineUserTracker;
+        _httpContextAccessor = httpContextAccessor;
+  
+    }
+
+    public override async Task OnConnectionUpAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        await base.OnConnectionUpAsync(circuit, cancellationToken);
+    }
+
+    public override async Task OnConnectionDownAsync(Circuit circuit, CancellationToken cancellationToken)
+    {
+        var userId = _httpContextAccessor.HttpContext?.User.GetUserId();
+
+        if (!string.IsNullOrEmpty(userId))
+        {
+            await _userSessionTracker.RemoveAllSessions(userId, cancellationToken);
+            await _onlineUserTracker.Clear(userId, cancellationToken);
+        }
+
+        await base.OnConnectionDownAsync(circuit, cancellationToken);
+    }
+}

--- a/src/Server.UI/Middlewares/UserSessionCircuitHandler.cs
+++ b/src/Server.UI/Middlewares/UserSessionCircuitHandler.cs
@@ -3,26 +3,45 @@ using Microsoft.AspNetCore.Components.Server.Circuits;
 
 namespace CleanArchitecture.Blazor.Server.UI.Middlewares;
 
+/// <summary>
+/// Handles user session tracking and online user tracking for Blazor server circuits.
+/// </summary>
 public class UserSessionCircuitHandler : CircuitHandler
 {
     private readonly IUserSessionTracker _userSessionTracker;
     private readonly IOnlineUserTracker _onlineUserTracker;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
-
-    public UserSessionCircuitHandler(IUserSessionTracker userSessionTracker, IOnlineUserTracker OnlineUserTracker, IHttpContextAccessor httpContextAccessor)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserSessionCircuitHandler"/> class.
+    /// </summary>
+    /// <param name="userSessionTracker">The user session tracker service.</param>
+    /// <param name="onlineUserTracker">The online user tracker service.</param>
+    /// <param name="httpContextAccessor">The HTTP context accessor.</param>
+    public UserSessionCircuitHandler(IUserSessionTracker userSessionTracker, IOnlineUserTracker onlineUserTracker, IHttpContextAccessor httpContextAccessor)
     {
         _userSessionTracker = userSessionTracker;
-        _onlineUserTracker = OnlineUserTracker;
+        _onlineUserTracker = onlineUserTracker;
         _httpContextAccessor = httpContextAccessor;
-  
     }
 
+    /// <summary>
+    /// Called when a new circuit connection is established.
+    /// </summary>
+    /// <param name="circuit">The circuit.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     public override async Task OnConnectionUpAsync(Circuit circuit, CancellationToken cancellationToken)
     {
         await base.OnConnectionUpAsync(circuit, cancellationToken);
     }
 
+    /// <summary>
+    /// Called when a circuit connection is disconnected.
+    /// </summary>
+    /// <param name="circuit">The circuit.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     public override async Task OnConnectionDownAsync(Circuit circuit, CancellationToken cancellationToken)
     {
         var userId = _httpContextAccessor.HttpContext?.User.GetUserId();

--- a/src/Server.UI/Pages/Contacts/Contacts.razor
+++ b/src/Server.UI/Pages/Contacts/Contacts.razor
@@ -46,7 +46,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
@@ -54,13 +54,13 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Add"
                                    OnClick="OnCreate">
                             @ConstantString.New
                         </MudButton>
                     }
-                    <MudMenu Variant="Variant.Outlined" TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
+                    <MudMenu  TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
                         @if (_canCreate)
                         {
                             <MudMenuItem Disabled="@(_selectedItems.Count != 1)" OnClick="OnClone">@ConstantString.Clone</MudMenuItem>

--- a/src/Server.UI/Pages/Contacts/CreateContact.razor
+++ b/src/Server.UI/Pages/Contacts/CreateContact.razor
@@ -37,7 +37,7 @@
           
         </MudCardContent>
         <MudCardActions Class="d-flex justify-end gap-2">
-            <MudLoadingButton Color="Color.Primary" DropShadow="false" Loading="@_saving" Variant="Variant.Outlined" OnClick="Submit">@ConstantString.Save</MudLoadingButton>
+            <MudLoadingButton Color="Color.Primary" DropShadow="false" Loading="@_saving"  OnClick="Submit">@ConstantString.Save</MudLoadingButton>
         </MudCardActions>
     </MudCard>
 </MudContainer>

--- a/src/Server.UI/Pages/Contacts/EditContact.razor
+++ b/src/Server.UI/Pages/Contacts/EditContact.razor
@@ -42,7 +42,7 @@
 
             </MudCardContent>
             <MudCardActions Class="d-flex justify-end gap-2">
-                <MudLoadingButton Color="Color.Primary" DropShadow="false" Loading="@_saving" Variant="Variant.Outlined" OnClick="Submit">@ConstantString.Save</MudLoadingButton>
+                <MudLoadingButton Color="Color.Primary" DropShadow="false" Loading="@_saving"  OnClick="Submit">@ConstantString.Save</MudLoadingButton>
             </MudCardActions>
         </MudCard>
     }

--- a/src/Server.UI/Pages/Documents/Documents.razor
+++ b/src/Server.UI/Pages/Documents/Documents.razor
@@ -41,7 +41,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh" >
@@ -49,7 +49,7 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Camera"
                                    OnClick="OnCreate">
                             @L["Upload Pictures"]
@@ -57,7 +57,7 @@
                     }
                     @if (_canDelete)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Delete"
                                    Disabled="@(!(_selectedItems.Count > 0))"
                                    OnClick="OnDeleteChecked">

--- a/src/Server.UI/Pages/Identity/Roles/Roles.razor
+++ b/src/Server.UI/Pages/Identity/Roles/Roles.razor
@@ -44,7 +44,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
@@ -52,13 +52,13 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Add"
                                    OnClick="OnCreate">
                             @ConstantString.New
                         </MudButton>
                     }
-                    <MudMenu Variant="Variant.Outlined" TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
+                    <MudMenu  TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
                         @if (_canDelete)
                         {
                             <MudMenuItem Disabled="@(!(_selectedItems.Count > 0))"

--- a/src/Server.UI/Pages/Identity/Users/Components/UserForm.razor
+++ b/src/Server.UI/Pages/Identity/Users/Components/UserForm.razor
@@ -55,11 +55,11 @@
             </MultiTenantAutocomplete>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.Provider)" @bind-Value="Model.Provider" Label="@L[Model.GetMemberDescription(x=>x.Provider)]" Variant="Variant.Text" ReadOnly></MudTextField>
+            <MudTextField For="@(() => Model.Provider)" @bind-Value="Model.Provider" Label="@L[Model.GetMemberDescription(x=>x.Provider)]"  ReadOnly></MudTextField>
         </MudItem>
 
         <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.UserName)" @bind-Value="Model.UserName" Label="@L[Model.GetMemberDescription(x=>x.UserName)]" Variant="Variant.Text" Required="true"></MudTextField>
+            <MudTextField For="@(() => Model.UserName)" @bind-Value="Model.UserName" Label="@L[Model.GetMemberDescription(x=>x.UserName)]"  Required="true"></MudTextField>
         </MudItem>
         <MudItem xs="12" sm="6">
             <div class="d-fex">
@@ -67,7 +67,7 @@
             </div>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.DisplayName)" @bind-Value="Model.DisplayName" Label="@L[Model.GetMemberDescription(x=>x.DisplayName)]" Variant="Variant.Text"></MudTextField>
+            <MudTextField For="@(() => Model.DisplayName)" @bind-Value="Model.DisplayName" Label="@L[Model.GetMemberDescription(x=>x.DisplayName)]" ></MudTextField>
         </MudItem>
         <MudItem xs="12" sm="6">
             <PickSuperiorIdAutocomplete For="@(() => Model.Superior)" T="ApplicationUserDto"
@@ -79,16 +79,16 @@
             </PickSuperiorIdAutocomplete>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.Email)" @bind-Value="Model.Email" Label="@L[Model.GetMemberDescription(x=>x.Email)]" Variant="Variant.Text" Required="true"></MudTextField>
+            <MudTextField For="@(() => Model.Email)" @bind-Value="Model.Email" Label="@L[Model.GetMemberDescription(x=>x.Email)]"  Required="true"></MudTextField>
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudTextField For="@(() => Model.PhoneNumber)" @bind-Value="Model.PhoneNumber" Label="@L[Model.GetMemberDescription(x=>x.PhoneNumber)]" Variant="Variant.Text"></MudTextField>
+            <MudTextField For="@(() => Model.PhoneNumber)" @bind-Value="Model.PhoneNumber" Label="@L[Model.GetMemberDescription(x=>x.PhoneNumber)]" ></MudTextField>
         </MudItem>
         <MudItem sm="6" xs="12">
-            <TimeZoneAutocomplete T="string" For="@(() => Model.TimeZoneId)" ShrinkLabel="true" @bind-Value="Model.TimeZoneId" Label="@L[Model.GetMemberDescription(x=>x.TimeZoneId)]" Variant="Variant.Text"></TimeZoneAutocomplete>
+            <TimeZoneAutocomplete T="string" For="@(() => Model.TimeZoneId)"  @bind-Value="Model.TimeZoneId" Label="@L[Model.GetMemberDescription(x=>x.TimeZoneId)]" ></TimeZoneAutocomplete>
         </MudItem>
         <MudItem sm="6" xs="12">
-            <LanguageAutocomplete T="string" For="@(() => Model.LanguageCode)" ShrinkLabel="true" @bind-Value="Model.LanguageCode" Label="@L[Model.GetMemberDescription(x=>x.LanguageCode)]" Variant="Variant.Text"></LanguageAutocomplete>
+            <LanguageAutocomplete T="string" For="@(() => Model.LanguageCode)"  @bind-Value="Model.LanguageCode" Label="@L[Model.GetMemberDescription(x=>x.LanguageCode)]" ></LanguageAutocomplete>
         </MudItem>
 
 
@@ -114,16 +114,16 @@
             </MudGrid>
         </MudItem>
         <MudItem sm="6" xs="12">
-            <MudTextField For="@(() => Model.CreatedBy)" Disabled ShrinkLabel="true" Value="Model.CreatedByUser?.UserName" Label="@L[Model.GetMemberDescription(x=>x.CreatedBy)]" Variant="Variant.Text"></MudTextField>
+            <MudTextField For="@(() => Model.CreatedBy)" Disabled  Value="Model.CreatedByUser?.UserName" Label="@L[Model.GetMemberDescription(x=>x.CreatedBy)]" ></MudTextField>
         </MudItem>
         <MudItem sm="6" xs="12">
-            <MudTextField T="string" Disabled ShrinkLabel="true" Value="@(Model.Created.ToLocalTime(UserProfile?.LocalTimeOffset))" Label="@L[Model.GetMemberDescription(x=>x.Created)]" Variant="Variant.Text"></MudTextField>
+            <MudTextField T="string" Disabled  Value="@(Model.Created.ToLocalTime(UserProfile?.LocalTimeOffset))" Label="@L[Model.GetMemberDescription(x=>x.Created)]" ></MudTextField>
         </MudItem>
         <MudItem sm="6" xs="12">
-            <MudTextField For="@(() => Model.LastModifiedBy)" Disabled ShrinkLabel="true" Value="Model.LastModifiedByUser?.UserName" Label="@L[Model.GetMemberDescription(x=>x.LastModifiedBy)]" Variant="Variant.Text"></MudTextField>
+            <MudTextField For="@(() => Model.LastModifiedBy)" Disabled  Value="Model.LastModifiedByUser?.UserName" Label="@L[Model.GetMemberDescription(x=>x.LastModifiedBy)]" ></MudTextField>
         </MudItem>
         <MudItem sm="6" xs="12">
-            <MudTextField T="string" Disabled ShrinkLabel="true" Value="@(Model.LastModified.ToLocalTime(UserProfile?.LocalTimeOffset))" Label="@L[Model.GetMemberDescription(x=>x.LastModified)]" Variant="Variant.Text"></MudTextField>
+            <MudTextField T="string" Disabled  Value="@(Model.LastModified.ToLocalTime(UserProfile?.LocalTimeOffset))" Label="@L[Model.GetMemberDescription(x=>x.LastModified)]" ></MudTextField>
         </MudItem>
     </MudGrid>
 </MudForm>

--- a/src/Server.UI/Pages/Identity/Users/Profile.razor
+++ b/src/Server.UI/Pages/Identity/Users/Profile.razor
@@ -68,31 +68,31 @@ else
                         </div>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <MudTextField For="@(() => model.TenantName)" ShrinkLabel="true" @bind-Value="model.TenantName" Label="@L["Tenant Name"]" Variant="Variant.Text" ReadOnly="true"></MudTextField>
+                        <MudTextField For="@(() => model.TenantName)"  @bind-Value="model.TenantName" Label="@L["Tenant Name"]"  ReadOnly="true"></MudTextField>
                     </MudItem>
                     <MudItem xs="12" sm="6">
-                        <MudTextField For="@(() => model.SuperiorName)" ShrinkLabel="true" @bind-Value="model.SuperiorName" Label="@L["Superior Name"]" Variant="Variant.Text" ReadOnly="true"></MudTextField>
+                        <MudTextField For="@(() => model.SuperiorName)"  @bind-Value="model.SuperiorName" Label="@L["Superior Name"]"  ReadOnly="true"></MudTextField>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <MudTextField For="@(() => model.UserName)" ShrinkLabel="true" @bind-Value="model.UserName" Label="@L["User Name"]" Variant="Variant.Text" ReadOnly="true"></MudTextField>
+                        <MudTextField For="@(() => model.UserName)"  @bind-Value="model.UserName" Label="@L["User Name"]"  ReadOnly="true"></MudTextField>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <MudTextField For="@(() => model.Email)" ShrinkLabel="true" @bind-Value="model.Email" Label="@L["Email"]" Variant="Variant.Text" ReadOnly="true"></MudTextField>
+                        <MudTextField For="@(() => model.Email)"  @bind-Value="model.Email" Label="@L["Email"]"  ReadOnly="true"></MudTextField>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <MudTextField For="@(() => model.DisplayName)" ShrinkLabel="true" @bind-Value="model.DisplayName" Label="@L["Full Name"]" Variant="Variant.Text"></MudTextField>
+                        <MudTextField For="@(() => model.DisplayName)"  @bind-Value="model.DisplayName" Label="@L["Full Name"]" ></MudTextField>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <MudTextField For="@(() => model.PhoneNumber)" ShrinkLabel="true" @bind-Value="model.PhoneNumber" Label="@L["Phone Number"]" Variant="Variant.Text"></MudTextField>
+                        <MudTextField For="@(() => model.PhoneNumber)"  @bind-Value="model.PhoneNumber" Label="@L["Phone Number"]" ></MudTextField>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <TimeZoneAutocomplete T="string" For="@(() => model.TimeZoneId)" ShrinkLabel="true" @bind-Value="model.TimeZoneId" Label="@L["Time Zone"]" Variant="Variant.Text"></TimeZoneAutocomplete>
+                        <TimeZoneAutocomplete T="string" For="@(() => model.TimeZoneId)"  @bind-Value="model.TimeZoneId" Label="@L["Time Zone"]" ></TimeZoneAutocomplete>
                     </MudItem>
                     <MudItem sm="6" xs="12">
-                        <LanguageAutocomplete T="string" For="@(() => model.LanguageCode)" ShrinkLabel="true" @bind-Value="model.LanguageCode" Label="@L["Language"]" Variant="Variant.Text"></LanguageAutocomplete>
+                        <LanguageAutocomplete T="string" For="@(() => model.LanguageCode)"  @bind-Value="model.LanguageCode" Label="@L["Language"]" ></LanguageAutocomplete>
                     </MudItem>
                     <MudItem sm="12" xs="12" Class="d-flex justify-end">
-                        <MudButton ButtonType="ButtonType.Button" Disabled="@_submitting" Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto" OnClick="@(async () => await Submit())">
+                        <MudButton ButtonType="ButtonType.Button" Disabled="@_submitting"  Color="Color.Primary" Class="ml-auto" OnClick="@(async () => await Submit())">
                             @if (_submitting)
                             {
                                 <MudProgressCircular Class="ms-n1" Size="MudBlazor.Size.Small" Indeterminate="true" />
@@ -115,7 +115,7 @@ else
                                       Label="@L["Current Password"]"
                                           For="@(() => _changepassword.CurrentPassword)"
                                           @bind-Value="_changepassword.CurrentPassword"
-                                          Variant="Variant.Text"
+                                          
                                           Required="true" />
                     </MudItem>
                     <MudItem xs="12">
@@ -123,7 +123,7 @@ else
                                           Label="@L["New Password"]"
                                           For="@(() => _changepassword.NewPassword)"
                                           @bind-Value="_changepassword.NewPassword"
-                                          Variant="Variant.Text"
+                                          
                                           Required="true" />
                     </MudItem>
                     <MudItem xs="12">
@@ -131,11 +131,11 @@ else
                                           Label="@L["Confirm New Password"]"
                                           For="@(() => _changepassword.ConfirmPassword)"
                                           @bind-Value="_changepassword.ConfirmPassword"
-                                          Variant="Variant.Text"
+                                          
                                           Required="true" />
                     </MudItem>
                     <MudItem sm="12" xs="12" Class="d-flex justify-end">
-                        <MudButton ButtonType="ButtonType.Button" Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto" OnClick="@(async () => await ChangePassword())">
+                        <MudButton ButtonType="ButtonType.Button"  Color="Color.Primary" Class="ml-auto" OnClick="@(async () => await ChangePassword())">
                             @if (_submitting)
                             {
                                 <MudProgressCircular Class="ms-n1" Size="MudBlazor.Size.Small" Indeterminate="true" />

--- a/src/Server.UI/Pages/Identity/Users/Users.razor
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor
@@ -66,7 +66,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
@@ -74,13 +74,13 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Add"
                                    OnClick="OnCreate">
                             @ConstantString.New
                         </MudButton>
                     }
-                    <MudMenu Variant="Variant.Outlined" TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
+                    <MudMenu  TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
                         @if (_canDelete)
                         {
                             <MudMenuItem Disabled="@(!(_selectedItems.Count > 0))"

--- a/src/Server.UI/Pages/PicklistSets/PicklistSets.razor
+++ b/src/Server.UI/Pages/PicklistSets/PicklistSets.razor
@@ -41,7 +41,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
@@ -49,13 +49,13 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                         StartIcon="@Icons.Material.Outlined.Add"
                         OnClick="OnCreate">
                             @ConstantString.New
                         </MudButton>
                     }
-                    <MudMenu Variant="Variant.Outlined" TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
+                    <MudMenu  TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
                         @if (_canDelete)
                         {
                             <MudMenuItem Disabled="@(!(_selectedItems.Count > 0))"

--- a/src/Server.UI/Pages/Products/Products.razor
+++ b/src/Server.UI/Pages/Products/Products.razor
@@ -42,7 +42,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
@@ -50,13 +50,13 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined" 
+                        <MudButton  
                                    StartIcon="@Icons.Material.Outlined.Add"
                                    OnClick="OnCreate">
                             @ConstantString.New
                         </MudButton>
                     }
-                    <MudMenu Variant="Variant.Outlined" TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
+                    <MudMenu  TransformOrigin="Origin.BottomRight" AnchorOrigin="Origin.BottomRight" EndIcon="@Icons.Material.Filled.MoreVert" Label="@ConstantString.More">
                         @if (_canCreate)
                         {
                             <MudMenuItem Disabled="@(_selectedItems.Count != 1)" OnClick="OnClone">@ConstantString.Clone</MudMenuItem>

--- a/src/Server.UI/Pages/SystemManagement/AuditTrails.razor
+++ b/src/Server.UI/Pages/SystemManagement/AuditTrails.razor
@@ -31,7 +31,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
                         @ConstantString.Refresh

--- a/src/Server.UI/Pages/SystemManagement/Logs.razor
+++ b/src/Server.UI/Pages/SystemManagement/Logs.razor
@@ -35,14 +35,14 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
                         @ConstantString.Refresh
                     </MudButton>
                     @if (_canPurge)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    Disabled="@(_clearing)"
                                    OnClick="@(OnPurge)"
                                    StartIcon="@Icons.Material.Outlined.ClearAll">

--- a/src/Server.UI/Pages/Tenants/Tenants.razor
+++ b/src/Server.UI/Pages/Tenants/Tenants.razor
@@ -31,7 +31,7 @@
             </MudStack>
             <MudStack Spacing="0" AlignItems="AlignItems.End">
                 <MudToolBar Dense WrapContent="true" Class="py-1 px-0">
-                    <MudButton Variant="Variant.Outlined"
+                    <MudButton 
                                Disabled="@_loading"
                                OnClick="@(() => OnRefresh())"
                                StartIcon="@Icons.Material.Outlined.Refresh">
@@ -39,7 +39,7 @@
                     </MudButton>
                     @if (_canCreate)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Add"
                                    OnClick="OnCreate">
                             @ConstantString.New
@@ -47,7 +47,7 @@
                     }
                     @if (_canDelete)
                     {
-                        <MudButton Variant="Variant.Outlined"
+                        <MudButton 
                                    StartIcon="@Icons.Material.Outlined.Delete"
                                    Disabled="@(!(_selectedItems.Count > 0))"
                                    OnClick="OnDeleteChecked">

--- a/src/Server.UI/Server.UI.csproj
+++ b/src/Server.UI/Server.UI.csproj
@@ -15,28 +15,20 @@
         <LangVersion>default</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        
         <PackageReference Include="BlazorDownloadFile" Version="2.4.0.2" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
-        <PackageReference Include="ActualLab.Fusion.Ext.Services" Version="9.5.54" />
-        <PackageReference Include="MudBlazor" Version="7.14.0" />
+        <PackageReference Include="MudBlazor" Version="7.15.0" />
         <PackageReference Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
         <PackageReference Include="Blazor-ApexCharts" Version="3.5.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="ActualLab.Fusion" Version="9.5.54" />
-        <PackageReference Include="ActualLab.Fusion.Blazor" Version="9.5.54" />
-        <PackageReference Include="MemoryPack.Generator" Version="1.21.3">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="ActualLab.Generators" Version="9.5.54">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="ActualLab.Fusion" Version="9.5.59" />
+        <PackageReference Include="ActualLab.Fusion.Blazor" Version="9.5.59" />
+        <PackageReference Include="ActualLab.Generators" Version="9.5.59"/>
+          
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Migrators\Migrators.MSSQL\Migrators.MSSQL.csproj" />

--- a/src/Server.UI/Services/Fusion/IOnlineUserTracker.cs
+++ b/src/Server.UI/Services/Fusion/IOnlineUserTracker.cs
@@ -1,42 +1,16 @@
-﻿using System.Runtime.Serialization;
-using ActualLab.Fusion;
-using ActualLab.Fusion.Blazor;
-using MemoryPack;
+﻿using ActualLab.Fusion;
 
 namespace CleanArchitecture.Blazor.Server.UI.Services.Fusion;
 
 public interface IOnlineUserTracker : IComputeService
 {
-    Task Add(string sessionId, UserInfo userInfo, CancellationToken cancellationToken = default);
-    Task Remove(string sessionId, CancellationToken cancellationToken = default);
+    Task Initial(SessionInfo sessionInfo,CancellationToken cancellationToken = default);
+    Task Logout(CancellationToken cancellationToken = default);
+    Task Clear(string userId,CancellationToken cancellationToken = default);
     Task Update(string userId,string userName,string displayName,string profilePictureDataUrl, CancellationToken cancellationToken = default);
     [ComputeMethod]
-    Task<UserInfo[]> GetOnlineUsers(CancellationToken cancellationToken = default);
+    Task<List<SessionInfo>> GetOnlineUsers(CancellationToken cancellationToken = default);
 
 }
 
-[DataContract, MemoryPackable]
-[ParameterComparer(typeof(ByValueParameterComparer))]
-public sealed partial record UserInfo(
-   [property: DataMember] string Id,
-   [property: DataMember] string Name,
-   [property: DataMember] string Email,
-   [property: DataMember] string DisplayName,
-   [property: DataMember] string ProfilePictureDataUrl,
-   [property: DataMember] string SuperiorName,
-   [property: DataMember] string SuperiorId,
-   [property: DataMember] string TenantId,
-   [property: DataMember] string TenantName,
-   [property: DataMember] string? PhoneNumber,
-   [property: DataMember] string[] AssignedRoles,
-   [property: DataMember] UserPresence Status
-);
-public enum UserPresence
-{
-    Available,
-    Busy,
-    Donotdisturb,
-    Away,
-    Offline,
-    Statusunknown
-}
+ 

--- a/src/Server.UI/Services/Fusion/IUserSessionTracker.cs
+++ b/src/Server.UI/Services/Fusion/IUserSessionTracker.cs
@@ -1,11 +1,39 @@
-﻿using ActualLab.Fusion;
+﻿using System.Runtime.Serialization;
+using ActualLab.Fusion;
+using ActualLab.Fusion.Blazor;
+using MemoryPack;
+using MessagePack;
 
 namespace CleanArchitecture.Blazor.Server.UI.Services.Fusion;
 
 public interface IUserSessionTracker: IComputeService
 {
-    Task AddUserSession(string pageComponent, string userName, CancellationToken cancellationToken = default);
-    Task RemoveUserSession(string pageComponent, string userName, CancellationToken cancellationToken = default);
+    Task AddUserSession(string pageComponent, CancellationToken cancellationToken = default);
+    Task RemoveUserSession(string pageComponent,  CancellationToken cancellationToken = default);
+    Task RemoveAllSessions(string userId, CancellationToken cancellationToken = default);
+   
     [ComputeMethod]
-    Task<(string PageComponent, string[] UserSessions)[]> GetUserSessions( CancellationToken cancellationToken = default);
+    Task<List<SessionInfo>> GetUserSessions(string pageComponent,CancellationToken cancellationToken = default);
+}
+[DataContract, MemoryPackable, MessagePackObject]
+[ParameterComparer(typeof(ByValueParameterComparer))]
+public sealed partial record SessionInfo(
+    [property: DataMember, Key(0)] string UserId,
+    [property: DataMember, Key(1)] string UserName,
+    [property: DataMember, Key(2)] string DisplayName,
+    [property: DataMember, Key(3)] string IPAddress,
+    [property: DataMember, Key(4)] string TenantId,
+    [property: DataMember, Key(5)] string ProfilePictureDataUrl,
+    [property: DataMember, Key(6)] UserPresence Status
+
+    )
+{ }
+public enum UserPresence
+{
+    Available,
+    Busy,
+    Donotdisturb,
+    Away,
+    Offline,
+    Statusunknown
 }

--- a/src/Server.UI/Services/Fusion/UserSessionTracker.cs
+++ b/src/Server.UI/Services/Fusion/UserSessionTracker.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Immutable;
-using System.Net.Http;
 using ActualLab.Fusion;
-using Microsoft.AspNetCore.Http;
 
 namespace CleanArchitecture.Blazor.Server.UI.Services.Fusion;
 

--- a/src/Server.UI/Services/Fusion/UserSessionTracker.cs
+++ b/src/Server.UI/Services/Fusion/UserSessionTracker.cs
@@ -70,10 +70,10 @@ public class UserSessionTracker : IUserSessionTracker
         _ = await GetUserSessions(pageComponent, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual async Task RemoveAllSessions(string userId, CancellationToken cancellationToken = default)
+    public virtual  Task RemoveAllSessions(string userId, CancellationToken cancellationToken = default)
     {
         if (Invalidation.IsActive)
-            return;
+            return Task.CompletedTask;
 
         foreach (var pageComponent in _pageUserSessions.Keys.ToList())
         {
@@ -96,6 +96,7 @@ public class UserSessionTracker : IUserSessionTracker
                 }
             }
         }
+        return Task.CompletedTask;
     }
     private  Task<SessionInfo> GetSessionInfo()
     {

--- a/src/Server.UI/Services/Fusion/UserSessionTracker.cs
+++ b/src/Server.UI/Services/Fusion/UserSessionTracker.cs
@@ -1,57 +1,116 @@
 ﻿using System.Collections.Immutable;
+using System.Net.Http;
 using ActualLab.Fusion;
+using Microsoft.AspNetCore.Http;
 
 namespace CleanArchitecture.Blazor.Server.UI.Services.Fusion;
 
 public class UserSessionTracker : IUserSessionTracker
 {
-
-    private volatile ImmutableDictionary<string, ImmutableHashSet<string>> _pageUserSessions = ImmutableDictionary<string, ImmutableHashSet<string>>.Empty;
-
-    public async Task AddUserSession(string pageComponent, string userName, CancellationToken cancellationToken = default)
+    public UserSessionTracker(IHttpContextAccessor  httpContextAccessor)
     {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    private volatile ImmutableDictionary<string, ImmutableHashSet<SessionInfo>> _pageUserSessions = ImmutableDictionary<string, ImmutableHashSet<SessionInfo>>.Empty;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public virtual async Task AddUserSession(string pageComponent, CancellationToken cancellationToken = default)
+    {
+
         if (Invalidation.IsActive)
             return;
-        if (_pageUserSessions.TryGetValue(pageComponent, out var existingUsers))
-        {
-            if (!existingUsers.Contains(userName))
-            {
-                var updatedUsers = existingUsers.Add(userName);
-                _pageUserSessions = _pageUserSessions.SetItem(pageComponent, updatedUsers);
-            }
-        }
-        else
-        {
-            _pageUserSessions = _pageUserSessions.Add(pageComponent, ImmutableHashSet.Create(userName));
-        }
+        var sessionInfo = await GetSessionInfo().ConfigureAwait(false);
+        ImmutableInterlocked.AddOrUpdate(
+            ref _pageUserSessions,
+            pageComponent,
+            ImmutableHashSet.Create(sessionInfo),
+            (key, existingSessions) => existingSessions.Add(sessionInfo));
+
         using var invalidating = Invalidation.Begin();
-         _ = await GetUserSessions(cancellationToken).ConfigureAwait(false);
-       
+        _ = await GetUserSessions(pageComponent, cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual  Task<(string PageComponent, string[] UserSessions)[]> GetUserSessions(CancellationToken cancellationToken = default)
+    public virtual  Task<List<SessionInfo>> GetUserSessions(string pageComponent,CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(_pageUserSessions.Select(kvp => (kvp.Key, kvp.Value.ToArray())).ToArray());
+        if (_pageUserSessions.TryGetValue(pageComponent, out var sessions))
+        {
+            return Task.FromResult(sessions.ToList());
+        }
+
+        return Task.FromResult(new List<SessionInfo>());
     }
 
-    public async Task RemoveUserSession(string pageComponent, string userName, CancellationToken cancellationToken = default)
+    public virtual async Task RemoveUserSession(string pageComponent, CancellationToken cancellationToken = default)
     {
         if (Invalidation.IsActive)
             return;
-        if (_pageUserSessions.TryGetValue(pageComponent, out var users) && users.Contains(userName))
+        var sessionInfo = await GetSessionInfo().ConfigureAwait(false);
+
+        if (_pageUserSessions.TryGetValue(pageComponent, out var users) && users.Contains(sessionInfo))
         {
-            var updatedUsers = users.Remove(userName);
+            var updatedUsers = users.Remove(sessionInfo);
+
+            // Use atomic update to prevent concurrency issues
             if (updatedUsers.IsEmpty)
             {
-                _pageUserSessions = _pageUserSessions.Remove(pageComponent);
+                ImmutableInterlocked.TryRemove(ref _pageUserSessions, pageComponent, out _);
             }
             else
             {
-                _pageUserSessions = _pageUserSessions.SetItem(pageComponent, updatedUsers);
+                ImmutableInterlocked.AddOrUpdate(
+                    ref _pageUserSessions,
+                    pageComponent,
+                    updatedUsers,
+                    (key, existingUsers) => updatedUsers);
             }
         }
 
         using var invalidating = Invalidation.Begin();
-        _ = await GetUserSessions(cancellationToken).ConfigureAwait(false);
+        _ = await GetUserSessions(pageComponent, cancellationToken).ConfigureAwait(false);
     }
+
+    public virtual async Task RemoveAllSessions(string userId, CancellationToken cancellationToken = default)
+    {
+        if (Invalidation.IsActive)
+            return;
+
+        foreach (var pageComponent in _pageUserSessions.Keys.ToList())
+        {
+            if (_pageUserSessions.TryGetValue(pageComponent, out var users))
+            {
+                var updatedUsers = users.Where(user => user.UserId != userId).ToImmutableHashSet();
+
+                // Use atomic update to prevent concurrency issues
+                if (updatedUsers.IsEmpty)
+                {
+                    ImmutableInterlocked.TryRemove(ref _pageUserSessions, pageComponent, out _);
+                }
+                else
+                {
+                    ImmutableInterlocked.AddOrUpdate(
+                        ref _pageUserSessions,
+                        pageComponent,
+                        updatedUsers,
+                        (key, existingUsers) => updatedUsers);
+                }
+            }
+        }
+    }
+    private  Task<SessionInfo> GetSessionInfo()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext == null)
+        {
+            throw new InvalidOperationException("HttpContext is not available.");
+        }
+        var httpUser = _httpContextAccessor.HttpContext?.User;
+        var ipAddress = _httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+        var userId = _httpContextAccessor.HttpContext?.User?.GetUserId();
+        var userName = _httpContextAccessor.HttpContext?.User?.GetUserName();
+        var displayName = _httpContextAccessor.HttpContext?.User?.GetDisplayName();
+        var tenantId = _httpContextAccessor.HttpContext?.User?.GetTenantId();
+        return Task.FromResult(new SessionInfo(userId, userName, displayName, ipAddress,tenantId,"", UserPresence.Available));
+    }
+
 }


### PR DESCRIPTION
Refactored OnlineUserTracker and UserSessionTracker.

Added UserSessionCircuitHandler to enhance user session management.

Fixed an issue where user sessions were not being properly cleaned up after the browser was closed.

remove Variant instead of MudGlobal.InputDefaults.Variant