### PR TITLE
Add permission to view online status

### DIFF
--- a/src/Infrastructure/PermissionSet/Permissions.cs
+++ b/src/Infrastructure/PermissionSet/Permissions.cs
@@ -76,6 +76,7 @@ public static partial class Permissions
         public const string SendRestPasswordMail = "Permissions.Users.SendRestPasswordMail";
         public const string ManagePermissions = "Permissions.Users.Permissions";
         public const string Deactivation = "Permissions.Users.Activation/Deactivation";
+        public const string ViewOnlineStatus = "Permissions.Users.ViewOnlineStatus";
     }
 
     [DisplayName("Role Permissions")]

--- a/src/Server.UI/Components/Identity/UserLoginState.razor
+++ b/src/Server.UI/Components/Identity/UserLoginState.razor
@@ -17,9 +17,16 @@
 
     [Inject] private HubClient Client { get; set; } = default!;
 
+    [CascadingParameter]
+    private Task<AuthenticationState> AuthState { get; set; } = default!;
+
+    private bool _canViewOnlineStatus;
+
     protected override async Task OnInitializedAsync()
     {
 
+        AuthenticationState state = await AuthState;
+        _canViewOnlineStatus = (await AuthService.AuthorizeAsync(state.User, Permissions.Users.ViewOnlineStatus)).Succeeded;
         Client.LoginEvent += _client_Login;
         Client.LogoutEvent += _client_Logout;
         await Client.StartAsync();
@@ -27,6 +34,8 @@
     }
     private void _client_Login(object? sender, UserStateChangeEventArgs args)
     {
+        if (!_canViewOnlineStatus) return;
+
         InvokeAsync(() =>
         {
             Snackbar.Add(string.Format(L["{0} has logged in."], args.UserName), Severity.Info);
@@ -35,6 +44,8 @@
 
     private void _client_Logout(object? sender, UserStateChangeEventArgs args)
     {
+        if (!_canViewOnlineStatus) return;
+
         InvokeAsync(() =>
         {
             Snackbar.Add(string.Format(L["{0} has logged out."], args.UserName));

--- a/src/Server.UI/Pages/Identity/Users/Components/UserCard.razor
+++ b/src/Server.UI/Pages/Identity/Users/Components/UserCard.razor
@@ -5,7 +5,7 @@
 @if (Item is not null)
 {
     <MudStack Row Spacing="2" AlignItems="AlignItems.Center">
-        <MudBadge Color="@(IsOnline() ? Color.Success : Color.Error)" Overlap="false" Dot="true" Bordered="true">
+        <MudBadge Color="@(IsOnline() ? Color.Success : Color.Error)" Overlap="false" Dot="true" Bordered="true" Visible="@DisplayOnlineStatus">
             <MudAvatar>
                 @if (string.IsNullOrEmpty(Item.ProfilePictureDataUrl))
                 {
@@ -51,6 +51,8 @@ else
     public ApplicationUserDto? Item { get; set; }
     [Parameter]
     public Func<ApplicationUserDto, Task>? OnSendVerify { get; set; }
+    [Parameter]
+    public bool DisplayOnlineStatus { get; set; }
 
     private bool IsOnline()
     {

--- a/src/Server.UI/Pages/Identity/Users/Users.razor
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor
@@ -182,7 +182,7 @@
         </PropertyColumn>
         <PropertyColumn Property="x => x.UserName" Title="@L[_currentDto.GetMemberDescription(x => x.UserName)]">
             <CellTemplate>
-                <UserCard Item="@context.Item" OnSendVerify="@(x=> SendVerify(x))"></UserCard>
+                <UserCard Item="@context.Item" OnSendVerify="@(x=> SendVerify(x))" DisplayOnlineStatus="@_canViewOnlineStatus"></UserCard>
             </CellTemplate>
         </PropertyColumn>
         <PropertyColumn Property="x => x.Email" Title="@L["Full Name"]">
@@ -279,6 +279,7 @@
     private bool _loading;
     private bool _exporting;
     private bool _uploading;
+    private bool _canViewOnlineStatus;
     private List<string?> _roles = new();
     private string? _searchRole;
 
@@ -297,6 +298,7 @@
         _canManagePermissions = (await AuthService.AuthorizeAsync(state.User, Permissions.Users.ManagePermissions)).Succeeded;
         _canImport = (await AuthService.AuthorizeAsync(state.User, Permissions.Users.Import)).Succeeded;
         _canExport = (await AuthService.AuthorizeAsync(state.User, Permissions.Users.Export)).Succeeded;
+        _canViewOnlineStatus = (await AuthService.AuthorizeAsync(state.User, Permissions.Users.ViewOnlineStatus)).Succeeded;
         _roles = await RoleManager.Roles.Select(x => x.Name).ToListAsync();
 
         //var list= await  UserManager.Users.Include(x=>x.LastModifiedByUser).Include(x=>x.CreatedByUser).ToListAsync();


### PR DESCRIPTION
I didn't want everyone to instantly have access to view anyone who was online, so I added a permission setting to allow administrators to specify who can and can't see that status. Please feel free to let me know if my code needs any changes.