### PR TITLE
Set default language to English (en-US)

### DIFF
--- a/src/Infrastructure/Constants/Localization/LocalizationConstants.cs
+++ b/src/Infrastructure/Constants/Localization/LocalizationConstants.cs
@@ -6,6 +6,11 @@ namespace CleanArchitecture.Blazor.Infrastructure.Constants.Localization;
 public static class LocalizationConstants
 {
     public const string ResourcesPath = "Resources";
+    /// <summary>
+    /// Default language code. Set to English (en-US). 
+    /// Change to "zh-CN" for Chinese or other codes from SupportedLanguages.
+    /// </summary>
+    public const string DefaultLanguageCode = "en-US";
 
     public static readonly LanguageCode[] SupportedLanguages =
     {


### PR DESCRIPTION
## Localization Configuration Update

### Changes
- Set default language to English (en-US)
- Added clear documentation for `DefaultLanguageCode`
- Simplified language code annotation
```c#
public static class LocalizationConstants
{
    public const string ResourcesPath = "Resources";
    /// <summary>
    /// Default language code. Set to English (en-US). 
    /// Change to "zh-CN" for Chinese or other codes from SupportedLanguages.
    /// </summary>
    public const string DefaultLanguageCode = "en-US";

   ...
}
```