### PR TITLE
Typo "Created Toady"

### DIFF
--- a/src/Application/Features/Contacts/Specifications/ContactAdvancedFilter.cs
+++ b/src/Application/Features/Contacts/Specifications/ContactAdvancedFilter.cs
@@ -26,7 +26,7 @@ public enum ContactListView
     All,
     [Description("My")]
     My,
-    [Description("Created Toady")]
+    [Description("Created Today")]
     TODAY,
     [Description("Created within the last 30 days")]
     LAST_30_DAYS

--- a/src/Application/Features/PicklistSets/Specifications/PicklistSetAdvancedFilter.cs
+++ b/src/Application/Features/PicklistSets/Specifications/PicklistSetAdvancedFilter.cs
@@ -6,7 +6,7 @@ public enum PickListView
     All,
     [Description("My")]
     My,
-    [Description("Created Toady")]
+    [Description("Created Today")]
     TODAY,
     [Description("Created within the last 30 days")]
     LAST_30_DAYS


### PR DESCRIPTION
Fixed into `Created Today`.

Before : 

![image](https://github.com/user-attachments/assets/a8f2506b-a6cb-450b-b998-cd33d4b66b96)

After : 

![image](https://github.com/user-attachments/assets/4d4a40ea-5fbe-44f8-a5d5-77fbcbf11958)
