### PR TITLE
Potential fix for code scanning alert no. 24: Log entries created from user input

### DIFF
--- a/src/Server.UI/Components/Shared/CustomError.razor
+++ b/src/Server.UI/Components/Shared/CustomError.razor
@@ -103,7 +103,8 @@
         }
 
         StackTrace = Exception.StackTrace;
-        Logger.LogError(Exception, "{Message}. request url: {@url} {@UserName}", Message, Navigation.Uri, userName);
+        var sanitizedUri = Navigation.Uri.Replace("\n", "").Replace("\r", "");
+        Logger.LogError(Exception, "{Message}. request url: {@url} {@UserName}", Message, sanitizedUri, userName);
     }
 
     private void OnRefresh()


### PR DESCRIPTION
Potential fix for [https://github.com/neozhu/CleanArchitectureWithBlazorServer/security/code-scanning/24](https://github.com/neozhu/CleanArchitectureWithBlazorServer/security/code-scanning/24)

To fix the issue, we need to sanitize the `Navigation.Uri` value before logging it. Since the log entry is plain text, we should remove any newline characters or other potentially problematic characters from the URI. This can be achieved using the `Replace` method to replace newline characters (`\n` and `\r`) with an empty string. This ensures that the log entry cannot be manipulated by user input.

The changes will be made in the `OnInitializedAsync` method, specifically on line 106 where the `Logger.LogError` method is called.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
