### PR TITLE
Fix: Only refresh UserProfileStateService when editing current logged in user

### DIFF
--- a/src/Server.UI/Pages/Identity/Users/Users.razor
+++ b/src/Server.UI/Pages/Identity/Users/Users.razor
@@ -450,7 +450,12 @@
             Snackbar.Add(Localizer["User updated successfully"], Severity.Info);
             await RefreshDataGrid();
             await UserService.RefreshAsync();
-            await UserProfileStateService.RefreshAsync(user.UserName);
+            // Only refresh UserProfileStateService if the updated user is the currently logged-in user
+            var authState = await AuthState;
+            if (model.Id == authState.User.GetUserId())
+            {
+                await UserProfileStateService.RefreshAsync(user.UserName);
+            }
             await OnlineUserTracker.Update(model.Id, model.UserName, model.DisplayName ?? string.Empty, model.ProfilePictureDataUrl ?? string.Empty);
         }
         else


### PR DESCRIPTION
## Problem
When an administrator edited any user from the users management page (`/identity/users`), the system would incorrectly switch the logged-in user context to the user being edited. This happened because `UserProfileStateService.RefreshAsync()` was being called with the edited user's username instead of checking if it was the current user.

## Solution
Added a check to only refresh the `UserProfileStateService` when the user being edited is the same as the currently logged-in user:

```csharp
// Only refresh UserProfileStateService if the updated user is the currently logged-in user
var authState = await AuthState;
if (model.Id == authState.User.GetUserId())
{
    await UserProfileStateService.RefreshAsync(user.UserName);
}

Files Changed
Users.razor

Testing
✅ Edit another user as admin - logged-in user context remains unchanged
✅ Edit own user profile - profile updates correctly

Please review and merge if everything looks good.