### PR TITLE
security: Update SixLabors.ImageSharp to 3.1.11

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="14.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
         <PackageReference Include="Ardalis.Specification" Version="9.2.0" />
         <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
         <PackageReference Include="ClosedXML" Version="0.105.0" />


### PR DESCRIPTION
- Fix moderate severity vulnerability GHSA-rxmq-m78w-7wmc
- Resolves infinite loop in GIF decoder with malformed comment blocks
- Update from 3.1.10 to 3.1.11 as recommended in security advisory

Please review and merge if everything looks good.